### PR TITLE
Move authentication to setup

### DIFF
--- a/auth_config.php
+++ b/auth_config.php
@@ -27,11 +27,11 @@
  * See code in library/Xerte/Authentication/*.php - where each file should match up to the value used below.
  */
 
-$xerte_toolkits_site->authentication_method = 'Guest';
-//$xerte_toolkits_site->authentication_method = 'Ldap';
-//$xerte_toolkits_site->authentication_method = 'Db';
-//$xerte_toolkits_site->authentication_method = 'Static';
-//$xerte_toolkits_site->authentication_method = "Moodle";
+// set authentication method to guest if not set in db via management area
+if (!isset($xerte_toolkits_site->authentication_method)) {
+    $xerte_toolkits_site->authentication_method = 'Guest';  
+    $res = db_query_one("insert into {$xerte_toolkits_site->database_table_prefix}sitedetails (`site_id`, `authentication_method`) values (1,'Guest')");
+}
 
 //restrict moodle guest access
 //comment out the following if you want the Moodle guest account to have authoring access

--- a/languages/en-GB/website_code/php/management/site.inc
+++ b/languages/en-GB/website_code/php/management/site.inc
@@ -144,6 +144,10 @@
 
 	define("MANAGEMENT_SITE_PROXY_EXPLAINED", "By directly editing the rss proxy.php file (in the root folder), you can add up to 4 proxys and ports should you wish.");
 
+  define("MANAGEMENT_SITE_AUTH_DETAILS", "Authentication settings");
+
+  define("MANAGEMENT_SITE_AUTH_METHOD", "The authentication method to use");
+
   define("MANAGEMENT_SITE_LTI","LTI settings");
 
 define("LTI_TOGGLE","View");

--- a/setup/basic.sql
+++ b/setup/basic.sql
@@ -93,6 +93,7 @@ CREATE TABLE `$sitedetails` (
   `apache` char(255) DEFAULT NULL,
   `mimetypes` text,
   `site_session_name` char(255) DEFAULT NULL,
+  `authentication_method` char(255) DEFAULT NULL,
   `LDAP_preference` char(255) DEFAULT NULL,
   `LDAP_filter` char(255) DEFAULT NULL,
   `integration_config_path` char(255) DEFAULT NULL,

--- a/setup/index.php
+++ b/setup/index.php
@@ -57,7 +57,7 @@ else: ?>
 
     	<p>The next pages will help you verify and solve system issues. You will not be able to continue until all requirements are fulfilled.</p>
 
-			<a href="requirements.php"><button>Press here to install</button></a>
+			<a href="requirements.php"><button>Install</button></a>
 
 <?php require_once('page_footer.php'); ?>
 

--- a/setup/index.php
+++ b/setup/index.php
@@ -1,4 +1,4 @@
-<?PHP 
+<?php 
 /**
  * Licensed to The Apereo Foundation under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for

--- a/setup/page3.php
+++ b/setup/page3.php
@@ -161,6 +161,24 @@ echo "<p>The site's proxy port is <textarea name=\"port1\"></textarea></p>";
 
 echo "<p>By directly editing the rss proxy.php file (in the root folder), you can add up to 4 proxies and ports should you wish.</p>";
 
+// Authentication method
+echo "<br><h3 style=\"clear:left\">Authentication Method</h3>";
+
+echo "<p>The default setting for user authentication is 'Guest' - which allows ANY visitor to access Xerte's front end with privileges to create, edit and delete ALL content. So… <span style=\"color: red;\">using <strong>'Guest' on a public web server</strong> (where anyone could access it) unless you have other security measures in place</span> is <strong  style=\"color: red;\">NOT recommended</strong>.</p>";
+
+echo "<p>See: <code>documentation/ToolkitsInstallationGuide.pdf</code> for details about each of the authentication options (Guest, Ldap, Db, Static, Moodle).</p>";
+
+echo "<label>Choose an authentication method:</label><br>";
+
+echo "<select name=\"authentication_method\" style=\"padding: 0.4em 0.15em; \">
+    		<option value=\"Guest\">Guest</option>
+    		<option value=\"Ldap\">Ldap</option>
+    		<option value=\"Db\">Db</option>
+    		<option value=\"Static\">Static</option>
+    		<option value=\"Moodle\">Moodle</option>
+  		</select>";
+
+echo "<br><br>";
 
 ?>
         <button type="submit">Save</button>

--- a/setup/page4.php
+++ b/setup/page4.php
@@ -68,7 +68,7 @@ foreach(array('news_text', 'pod_one', 'pod_two', 'form_string', 'peer_form_strin
 foreach(array('site_url', 'apache', 'mimetypes', 'LDAP_preference', 'LDAP_filter', 'integration_config_path', 'admin_username', 'admin_password', 'site_session_name', 
     'site_title', 'site_name', 'site_logo', 'organisational_logo','welcome_message', 'site_text', 'news_text', 'pod_one', 'pod_two', 'copyright', 'rss_title',
     'synd_publisher', 'synd_rights', 'synd_license', 'demonstration_page', 'form_string', 'peer_form_string', 'module_path', 'website_code_path', 'users_file_area_short', 
-    'php_library_path', 'error_log_path', 'email_error_list', 'error_log_message', 'error_email_message', 'max_error_size',
+    'php_library_path', 'error_log_path', 'email_error_list', 'error_log_message', 'max_error_size', 'max_error_size', 'error_email_message', 'authentication_method',
     'ldap_host', 'ldap_port', 'bind_pwd', 'basedn', 'bind_dn', 'flash_save_path', 'flash_upload_path', 'flash_preview_check_path', 'flash_flv_skin',
     'site_email_account', 'headers', 'email_to_add_to_username', 'proxy1', 'port1', 'feedback_list', 'play_edit_preview_query' ) as $field) {
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -395,4 +395,27 @@ function upgrade_6()
 	return true;
 }
 
+function upgrade_7()
+{
+    if (! _db_field_exists('sitedetails', 'authentication_method')) {
+        $error1 = _db_add_field('sitedetails', 'authentication_method', 'char(255)', '', 'site_session_name');      
+        $error_returned = true;
+        $res = db_query("insert into {$xerte_toolkits_site->database_table_prefix}sitedetails(authentication_method) VALUES ('Guest')");
+        if($res === false) {
+            die("Error creating authentication_method field");
+        }
+
+        if (($error1 === false)) {
+            $error_returned = false;
+            // echo "creating authentication_method field FAILED";
+        }
+
+        return "Creating authentication_method field - ok ? " . ($error_returned ? 'true' : 'false');
+    }
+    else
+    {
+        return "authentication_method field already present - ok ? true";
+    }
+}
+
 ?>

--- a/website_code/php/management/site.php
+++ b/website_code/php/management/site.php
@@ -151,6 +151,27 @@ if(is_user_admin()){
 
     echo "</div>";
 
+    echo "<div class=\"template\" id=\"authdetails\"><p>" . MANAGEMENT_SITE_AUTH_DETAILS . " <button type=\"button\" class=\"xerte_button\" id=\"authdetails_btn\" onclick=\"javascript:templates_display('authdetails')\">" . MANAGEMENT_VIEW . "</button></p></div><div class=\"template_details\" id=\"authdetails_child\">";
+
+    echo "<p>" . MANAGEMENT_SITE_AUTH_METHOD . "<form style=\"margin: top: 20px; padding: 4em 0.15em; \">";
+
+        echo "<select name=\"authentication_method\" id=\"authentication_method\" style=\"margin: 15px 0 0 10px; padding: 0.4em 0.15em; \">";
+
+        if(isset($row['authentication_method'])) {
+          echo "<option value=\"". $row['authentication_method'] . "\">". $row['authentication_method'] . "</option>";
+        }
+
+        echo "<option value=\"Guest\">Guest</option>
+              <option value=\"Ldap\">Ldap</option>
+              <option value=\"Db\">Db</option>
+              <option value=\"Static\">Static</option>
+              <option value=\"Moodle\">Moodle</option>
+            </select>";
+
+        echo "</form></p>"; 
+
+    echo "</div>";
+
     echo "<div class=\"template\" id=\"ldapdetails\"><p>" . MANAGEMENT_SITE_LDAP . " <button type=\"button\" class=\"xerte_button\" id=\"ldapdetails_btn\" onclick=\"javascript:templates_display('ldapdetails')\">" . MANAGEMENT_VIEW . "</button></p></div><div class=\"template_details\" id=\"ldapdetails_child\">";
 
     echo "<p>" . MANAGEMENT_SITE_LDAP_DELIMIT . "</p>";

--- a/website_code/php/management/site_details_management.php
+++ b/website_code/php/management/site_details_management.php
@@ -34,14 +34,14 @@ if(is_user_admin()) {
     $query = "update " . $xerte_toolkits_site->database_table_prefix . "sitedetails set site_url = ?, site_title = ?, site_name=?, site_logo=?, organisational_logo=?, welcome_message=?,
         site_text=? ,news_text=? ,pod_one=? , pod_two= ? ,copyright=? ,demonstration_page=? ,form_string= ? ,peer_form_string=?,feedback_list=?,
         rss_title=?, module_path=?, website_code_path=?, users_file_area_short=?, php_library_path=?, root_file_path=?, play_edit_preview_query=?, email_error_list=?, 
-        error_log_message=?, error_email_message=?, ldap_host=?, ldap_port=?, bind_pwd=?, basedn=?, bind_dn=?, flash_save_path=?, flash_upload_path=?, flash_preview_check_path=?, flash_flv_skin=? , site_email_account=?,
+        error_log_message=?, error_email_message=?, authentication_method=?, ldap_host=?, ldap_port=?, bind_pwd=?, basedn=?, bind_dn=?, flash_save_path=?, flash_upload_path=?, flash_preview_check_path=?, flash_flv_skin=? , site_email_account=?,
         headers=?, email_to_add_to_username=?, proxy1=?, port1=?, site_session_name=?, synd_publisher=?, synd_rights=?, synd_license=?,import_path=? ,
         apache=?, mimetypes=?, LDAP_preference=? ,LDAP_filter=? , integration_config_path=?, admin_username=? ,admin_password=? ";
 
     $data = array($_POST['site_url'], $_POST['site_title'], $_POST['site_name'], $_POST['site_logo'], $_POST['organisational_logo'], $_POST['welcome_message'], $site_texts, base64_encode(stripcslashes($_POST['news_text'])), base64_encode(stripcslashes($_POST['pod_one'])), base64_encode(stripcslashes($_POST['pod_two'])), $copyright, $_POST['demonstration_page'], base64_encode(stripcslashes($_POST['form_string'])),
         base64_encode(stripcslashes($_POST['peer_form_string'])), $_POST['feedback_list'], $_POST['rss_title'], $_POST['module_path'], $_POST['website_code_path'], $_POST['users_file_area_short'],
         $_POST['php_library_path'], str_replace("\\", "/", $_POST['root_file_path']), base64_encode(stripcslashes($_POST['play_edit_preview_query'])), $_POST['email_error_list'], $_POST['error_log_message'],
-        $_POST['error_email_message'], $_POST['ldap_host'], $_POST['ldap_port'], $_POST['bind_pwd'], $_POST['base_dn'], $_POST['bind_dn'], $_POST['flash_save_path'], $_POST['flash_upload_path'],
+        $_POST['error_email_message'], $_POST['authentication_method'], $_POST['ldap_host'], $_POST['ldap_port'], $_POST['bind_pwd'], $_POST['base_dn'], $_POST['bind_dn'], $_POST['flash_save_path'], $_POST['flash_upload_path'],
         $_POST['flash_preview_check_path'], $_POST['flash_flv_skin'], $_POST['site_email_account'], $_POST['headers'], $_POST['email_to_add_to_username'], $_POST['proxy1'], $_POST['port1'],
         $_POST['site_session_name'], $_POST['synd_publisher'], $_POST['synd_rights'], $_POST['synd_license'], str_replace("\\", "/", $_POST['import_path']), $_POST['apache'],
         $_POST['mimetypes'], $_POST['LDAP_preference'], $_POST['LDAP_filter'], $_POST['integration_config_path'], $_POST['admin_username'], $_POST['admin_password']);

--- a/website_code/scripts/management.js
+++ b/website_code/scripts/management.js
@@ -427,6 +427,7 @@ function update_site(){
 					 '&email_error_list=' + document.getElementById("error_email_list").value + 
 					 '&error_log_message=' + document.getElementById("error_log_message").value + 
 					 '&error_email_message=' + document.getElementById("error_email_message").value + 
+					 '&authentication_method=' + document.getElementById("authentication_method").value + 
 					 '&ldap_host=' + document.getElementById("ldap_host").value	+ 
 					 '&ldap_port=' + document.getElementById("ldap_port").value + 
 					 '&bind_pwd=' + document.getElementById("bind_pwd").value + 


### PR DESCRIPTION
This modification:
1.	Removes manual setting of $xerte_toolkits_site->authentication_method from auth_config.php
2.	adds a new option for setting ‘Authentication Method’ during the setup process (at the end of setup/page3.php). 
3.	adds a new option for setting ‘Authentication Method’ to the admin/management area. 
4.	adds upgrade function for existing installs

In response to http://lists.nottingham.ac.uk/pipermail/xerte-dev/2015-November/008118.html.

See screenshots and fuller logic attached.

[Xerte-Move-Authentication-to-Database.pdf](https://github.com/thexerteproject/xerteonlinetoolkits/files/34737/Xerte-Move-Authentication-to-Database.pdf)