### PR TITLE
Update xttracking_scorm1.2.js

### DIFF
--- a/modules/xerte/scorm1.2/xttracking_scorm1.2.js
+++ b/modules/xerte/scorm1.2/xttracking_scorm1.2.js
@@ -725,7 +725,7 @@ function ScormTrackingState()
         }
         else
         {
-            if (interactions_supported.indexOf('íd') < 0
+            if (interactions_supported.indexOf('id') < 0
                 || interactions_supported.indexOf('time') < 0
                 || interactions_supported.indexOf('type') < 0
                 || interactions_supported.indexOf('correct_responses') < 0


### PR DESCRIPTION
Misspelling int the line 728:
`if (interactions_supported.indexOf('íd') < 0`
Replacing "íd" by "id".
