### PR TITLE
Fix in xttracking_scorm scripts.

### DIFF
--- a/modules/xerte/scorm1.2/xttracking_scorm1.2.js
+++ b/modules/xerte/scorm1.2/xttracking_scorm1.2.js
@@ -612,6 +612,7 @@ function ScormTrackingState()
             var score = [];
             var weight = [];
             var totalweight = 0.0;
+            var i;
             // Walk passed the pages
             for (i=0; i<this.nrpages; i++)
             {

--- a/modules/xerte/scorm1.2/xttracking_scorm1.2.js
+++ b/modules/xerte/scorm1.2/xttracking_scorm1.2.js
@@ -545,10 +545,9 @@ function ScormTrackingState()
                     this.skipcomments = true;
                 }
             }
+            this.finishTracking(state.currentpageid, true);
+            doLMSCommit();
         }
-        this.finishTracking(state.currentpageid, true);
-        doLMSCommit();
-
     }
 
     function getSuccessStatus()

--- a/modules/xerte/scorm1.2/xttracking_scorm1.2.js
+++ b/modules/xerte/scorm1.2/xttracking_scorm1.2.js
@@ -400,11 +400,8 @@ function ScormTrackingState()
         if (sit != null && sit.exit())
         {
             if (this.scoremode == 'first' && sit.count > 1)
-            {
-                if (sit.ia_nr < 0)
-                    this.pages_visited++;
                 return;
-            }
+
             // Record this action
             var id = makeId(sit.page_nr, sit.ia_nr, sit.ia_type, sit.ia_name);
             var currnrinteractions = this.scorm_nr_interactions();

--- a/modules/xerte/scorm2004.3rd/xttracking_scorm2004.3rd.js
+++ b/modules/xerte/scorm2004.3rd/xttracking_scorm2004.3rd.js
@@ -372,11 +372,8 @@ function ScormTrackingState()
         if (sit != null && sit.exit())
         {
             if (this.scoremode == 'first' && sit.count > 1)
-            {
-                if (sit.ia_nr < 0)
-                    this.pages_visited++;
                 return;
-            }
+
 
             // Record this action
             var id = makeId(sit.page_nr, sit.ia_nr, sit.ia_type, sit.ia_name);


### PR DESCRIPTION
1) Removed a wrong increment of "pages_visited" when SCORM Tracking Mode is in "tracking of first pass". The pages_visited counter was incremented each time the page is accessed.
2) Fix a problem in SCORM 1.2. When a course with score is finished with status passed, moving fast between pages cause the status change to failed.