### PR TITLE
Fix bug #371

### DIFF
--- a/website_code/php/properties/access_change_template.php
+++ b/website_code/php/properties/access_change_template.php
@@ -75,10 +75,10 @@ if(isset($_POST['server_string'])){
 $params = array($access_to_whom, $_POST['template_id']);
 $ok = db_query($query, $params);
 
-if($ok) {
-    access_display($xerte_toolkits_site, true);
+if($ok === false) {
+    access_display_fail();
 
 }else {
 
-    access_display_fail();
+    access_display($xerte_toolkits_site, true);
 }


### PR DESCRIPTION
The function db_query(), when UPDATE query, return the number of rows affected,  if you don't change the access setting but still click 'change access', the function db_query() return 0, since no row has been changed. If execute query fail, return false.