### PR TITLE
Correct pathname used during deletes.

### DIFF
--- a/modules/decision/delete_template.php
+++ b/modules/decision/delete_template.php
@@ -53,18 +53,16 @@ function delete_folder_loop($path){
 	
 		if(($f!=".")&&($f!="..")){
 
-			if(is_dir($path . $f)){
-		
+			$string = $path . DIRECTORY_SEPARATOR . $f;
 
-				array_push($folder_array, $path . "/" . $f);	
+			if(is_dir($string)){
+
+				array_push($folder_array, $string);	
 				
-				delete_folder_loop($path . $f);
-
+				delete_folder_loop($string);
 			
 			}else{
 	
-				$string = $path . "/" . $f;
-
 				array_push($file_array, $string);
 			
 			}

--- a/modules/site/delete_template.php
+++ b/modules/site/delete_template.php
@@ -53,18 +53,16 @@ function delete_folder_loop($path){
 	
 		if(($f!=".")&&($f!="..")){
 
-			if(is_dir($path . $f)){
-		
+			$string = $path . DIRECTORY_SEPARATOR . $f;
 
-				array_push($folder_array, $path . "/" . $f);	
+			if(is_dir($string)){
+
+				array_push($folder_array, $string);	
 				
-				delete_folder_loop($path . $f);
-
+				delete_folder_loop($string);
 			
 			}else{
 	
-				$string = $path . "/" . $f;
-
 				array_push($file_array, $string);
 			
 			}

--- a/modules/xerte/delete_template.php
+++ b/modules/xerte/delete_template.php
@@ -1,5 +1,4 @@
 <?PHP     
-
 /**
  * Licensed to The Apereo Foundation under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for
@@ -18,7 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 /**
 * 
@@ -55,18 +53,16 @@ function delete_folder_loop($path){
 	
 		if(($f!=".")&&($f!="..")){
 
-			if(is_dir($path . $f)){
-		
+			$string = $path . DIRECTORY_SEPARATOR . $f;
 
-				array_push($folder_array, $path . "/" . $f);	
+			if(is_dir($string)){
+
+				array_push($folder_array, $string);	
 				
-				delete_folder_loop($path . $f);
-
+				delete_folder_loop($string);
 			
 			}else{
 	
-				$string = $path . "/" . $f;
-
 				array_push($file_array, $string);
 			
 			}


### PR DESCRIPTION
When deleting a project subdirectores and files can be left behind. In the function 'delete_folder_loop' the initial directory path is not set correctly - the directory separator is missing. This causes the subsequent 'is_dir' to fail, and so everything ends up being treated as a file. In the function 'clean_up_files' trying to delete the 'file' then fails because it is a directory.