### PR TITLE
Error config - fix for error handling settings

### DIFF
--- a/website_code/php/error_library.php
+++ b/website_code/php/error_library.php
@@ -51,10 +51,10 @@ function receive_message($user_name, $type, $level, $subject, $content){
 
 
     /*
-     * If error email message turned on, send an error email message 
+     * If error email list is set, send an error email message to those users
      */
 
-    if(isset($xerte_toolkits_site->error_email_message) && $xerte_toolkits_site->error_email_message=="true"){
+    if(isset($xerte_toolkits_site->email_error_list) && trim($xerte_toolkits_site->email_error_list) != false){
 
         email_message($user_name, $type, $level, $subject, $content);		
 
@@ -202,6 +202,6 @@ function email_message($user_name, $type, $level, $subject, $content){
 
     $email_content = date("G:i:s-d/m/Y") . "\n" . $content;
 
-    mail($xerte_toolkits_site->email_error_list, $email_subject, $email_content,get_email_headers());
+    mail($xerte_toolkits_site->email_error_list, $email_subject, $email_content, get_email_headers());
 
 }

--- a/website_code/php/management/site.php
+++ b/website_code/php/management/site.php
@@ -147,7 +147,7 @@ if(is_user_admin()){
 
     echo "<p>" . MANAGEMENT_SITE_ERROR_EMAIL . "<form><textarea id=\"error_email_list\">" . $row['email_error_list'] . "</textarea></form></p>";	
 
-    echo "<p>" . MANAGEMENT_SITE_ERROR_MAX . "<form><textarea id=\"error_email_message\">" . $row['max_error_size'] . "</textarea></form></p>";
+    echo "<p>" . MANAGEMENT_SITE_ERROR_MAX . "<form><textarea id=\"max_error_size\">" . $row['max_error_size'] . "</textarea></form></p>";
 
     echo "</div>";
 

--- a/website_code/php/management/site_details_management.php
+++ b/website_code/php/management/site_details_management.php
@@ -34,14 +34,14 @@ if(is_user_admin()) {
     $query = "update " . $xerte_toolkits_site->database_table_prefix . "sitedetails set site_url = ?, site_title = ?, site_name=?, site_logo=?, organisational_logo=?, welcome_message=?,
         site_text=? ,news_text=? ,pod_one=? , pod_two= ? ,copyright=? ,demonstration_page=? ,form_string= ? ,peer_form_string=?,feedback_list=?,
         rss_title=?, module_path=?, website_code_path=?, users_file_area_short=?, php_library_path=?, root_file_path=?, play_edit_preview_query=?, email_error_list=?, 
-        error_log_message=?, error_email_message=?, authentication_method=?, ldap_host=?, ldap_port=?, bind_pwd=?, basedn=?, bind_dn=?, flash_save_path=?, flash_upload_path=?, flash_preview_check_path=?, flash_flv_skin=? , site_email_account=?,
+        error_log_message=?, max_error_size=?, authentication_method=?, ldap_host=?, ldap_port=?, bind_pwd=?, basedn=?, bind_dn=?, flash_save_path=?, flash_upload_path=?, flash_preview_check_path=?, flash_flv_skin=?, site_email_account=?,
         headers=?, email_to_add_to_username=?, proxy1=?, port1=?, site_session_name=?, synd_publisher=?, synd_rights=?, synd_license=?,import_path=? ,
         apache=?, mimetypes=?, LDAP_preference=? ,LDAP_filter=? , integration_config_path=?, admin_username=? ,admin_password=?, LRS_Endpoint=?, LRS_Key=?, LRS_Secret=? ";
 
     $data = array($_POST['site_url'], $_POST['site_title'], $_POST['site_name'], $_POST['site_logo'], $_POST['organisational_logo'], $_POST['welcome_message'], $site_texts, base64_encode(stripcslashes($_POST['news_text'])), base64_encode(stripcslashes($_POST['pod_one'])), base64_encode(stripcslashes($_POST['pod_two'])), $copyright, $_POST['demonstration_page'], base64_encode(stripcslashes($_POST['form_string'])),
         base64_encode(stripcslashes($_POST['peer_form_string'])), $_POST['feedback_list'], $_POST['rss_title'], $_POST['module_path'], $_POST['website_code_path'], $_POST['users_file_area_short'],
         $_POST['php_library_path'], str_replace("\\", "/", $_POST['root_file_path']), base64_encode(stripcslashes($_POST['play_edit_preview_query'])), $_POST['email_error_list'], $_POST['error_log_message'],
-        $_POST['error_email_message'], $_POST['authentication_method'], $_POST['ldap_host'], $_POST['ldap_port'], $_POST['bind_pwd'], $_POST['base_dn'], $_POST['bind_dn'], $_POST['flash_save_path'], $_POST['flash_upload_path'],
+        $_POST['max_error_size'], $_POST['authentication_method'], $_POST['ldap_host'], $_POST['ldap_port'], $_POST['bind_pwd'], $_POST['base_dn'], $_POST['bind_dn'], $_POST['flash_save_path'], $_POST['flash_upload_path'],
         $_POST['flash_preview_check_path'], $_POST['flash_flv_skin'], $_POST['site_email_account'], $_POST['headers'], $_POST['email_to_add_to_username'], $_POST['proxy1'], $_POST['port1'],
         $_POST['site_session_name'], $_POST['synd_publisher'], $_POST['synd_rights'], $_POST['synd_license'], str_replace("\\", "/", $_POST['import_path']), $_POST['apache'],
         $_POST['mimetypes'], $_POST['LDAP_preference'], $_POST['LDAP_filter'], $_POST['integration_config_path'], $_POST['admin_username'], $_POST['admin_password'], $_POST['site_xapi_endpoint'], $_POST['site_xapi_key'], $_POST['site_xapi_secret']);

--- a/website_code/scripts/management.js
+++ b/website_code/scripts/management.js
@@ -382,7 +382,7 @@ function remove_security(){
 
 }
 
-// Function delete sharing template
+// Function update site
 //
 // remove a share, and check who did it
 
@@ -426,7 +426,7 @@ function update_site(){
 					 '&play_edit_preview_query=' + document.getElementById("play_edit_preview_query").value + 
 					 '&email_error_list=' + document.getElementById("error_email_list").value + 
 					 '&error_log_message=' + document.getElementById("error_log_message").value + 
-					 '&error_email_message=' + document.getElementById("error_email_message").value + 
+					 '&max_error_size=' + document.getElementById("max_error_size").value + 
 					 '&authentication_method=' + document.getElementById("authentication_method").value + 
 					 '&ldap_host=' + document.getElementById("ldap_host").value	+ 
 					 '&ldap_port=' + document.getElementById("ldap_port").value + 


### PR DESCRIPTION
When logged in as the admin, and selecting the 'Error handling settings', it is not possible to change the error log maximum (entry) size. The display box is present, but in the background it is tied to the 'error_email_message' entry (which governs whether an error log entry should be mailed to users). In addition the database 'max_error_size' entry is not updated (another mix up in the code).
It seems that the database entry 'error_email_message' (and textarea id from the admin UI) are never used. The entry is not actually required though since whether an error log entry should be emailed to users or not can easily be controlled by the 'email_error_list' value (which is a list of userids that should receive the email message). If the list is empty, then obviously no email should be sent.
The following patches correct the code, and allow the admin user to modify the relevant error handling settings.
