### PR TITLE
Plugins.php - ensure array variables are set before merging.

### DIFF
--- a/plugins.php
+++ b/plugins.php
@@ -43,6 +43,10 @@ require_once(dirname(__FILE__) . D_S . 'website_code' . D_S . 'php' . D_S . 'wp_
  */
 $files1 = glob(PLUGINS_PATH . D_S . '**' . D_S . '*.php');
 $files2 = glob(PLUGINS_PATH . D_S . '*.php');
+
+if ($files1 === false) $files1 = array();
+if ($files2 === false) $files2 = array();
+
 $files = array_merge($files1, $files2);
 
 foreach ($files as $file) {


### PR DESCRIPTION
The 'glob' function may return an error, and this will cause the following 'array_merge' and foreach calls to throw a warning:
"PHP Warning:  array_merge(): Argument #1 is not an array..."
"PHP Warning:  Invalid argument supplied for foreach() in..."
