### PR TITLE
Corrections to some of the messages displayed during setup

### DIFF
--- a/setup/page_password.php
+++ b/setup/page_password.php
@@ -32,9 +32,15 @@ $connection = $xot_setup->database->connect();
 
 if (!$connection) { ?>
 
-    <p>Sorry, the attempt to connect to MySql on the host <?php echo $_SESSION['DATABASE_HOST']; ?> has failed using account <?php echo $_POST['account']; ?>. MySQL reports the following error -</p>
+    <p>Sorry, the attempt to connect to MySQL on the host <?php echo $_SESSION['DATABASE_HOST']; ?> has failed using account <?php echo $_POST['account']; ?>. 
     
-    <p class="setup_error"><?php echo $connection->errorInfo(); ?></p>
+    <?php if ($connection->errorInfo() != ""): ?>
+        MySQL reports the following error -</p>
+        <p class="setup_error"><?php echo $connection->errorInfo(); ?></p>
+    <?php else: ?>
+        </p>
+        <p class="setup_error">MySQL has provided no error message.</p>
+    <?php endif; ?>
 
     <p>The account <?php echo $_POST['account']; ?> must already exist, and have access to database <?php echo $_SESSION['DATABASE_NAME'];?></p>
 <?php
@@ -63,7 +69,7 @@ if ($success)
     if (!$success)
     {
 ?>
-       <p>Sorry, the attempt to insert and delete records in MySql on the host <?php echo $_SESSION['DATABASE_HOST']; ?> has failed using account <?php echo $_POST['account']; ?>.</p>
+       <p>Sorry, the attempt to insert and delete records in MySQL on the host <?php echo $_SESSION['DATABASE_HOST']; ?> has failed using account <?php echo $_POST['account']; ?>.</p>
 
         <p>The account <?php echo $_POST['account']; ?> exists, but does not have enough privileges to access database <?php echo $_SESSION['DATABASE_NAME'];?></p>
 <?php

--- a/setup/php_modules.php
+++ b/setup/php_modules.php
@@ -27,23 +27,24 @@ $ok = true; $warning = false; ?>
             <ul>
                 <li>Look in the Ini file for <code>file_uploads =</code> and set the value to be On: <?php if ( ini_get("file_uploads" ) == 1 ) { echo "<div class=\"ok\">OK</div>"; } else { echo "div class=\"error\">Off</div>"; $ok = false; } ?></li>
 
-                <li>Look in the Ini file for <code>upload_tmp_dir =</code> and set the value to a path outside of the public area available to visitors to the web server (e.g if you are using XAMPP - you should not put the temp directory in the HTDOCS folder): try changing this setting to
-                <code><?php echo ini_get( "upload_tmp_dir" ); ?></code>
+                <li>Look in the Ini file for <code>upload_tmp_dir =</code> and set the value to a path outside of the public area available to visitors to the web server (e.g if you are using XAMPP - you should not put the temp directory in the HTDOCS folder): 
                 <?php if ( ini_get( "upload_tmp_dir" ) == "" ): $warning = true; ?>
                     <div class="warning">Not set!</div>
+                <?php else: ?>
+                    <code><?php echo ini_get( "upload_tmp_dir" ); ?></code>
                 <?php endif; ?></li>
 
-                <li>Look in the Ini file for <code>upload_max_filesize =</code> and set the value to an amount that you want to be the maximum file size you can upload. The format for this setting is the number, then the letter 'M': 
+                <li>Look in the Ini file for <code>upload_max_filesize =</code> and set the value to an amount that you want to be the maximum file size you can upload. The format for this setting is a number, then the letter 'M': 
                 <div class="info"><?php echo ini_get( "upload_max_filesize" );?></div></li>
 
-                <li>Look in the Ini file for <code>post_max_size =</code> and set the value to an amount that you want to be the maximum size of post data allowed. The format for this setting is the number, then the letter 'M':
+                <li>Look in the Ini file for <code>post_max_size =</code> and set the value to an amount that you want to be the maximum size of post data allowed. The format for this setting is a number, then the letter 'M':
                 <div class="info"><?php echo ini_get( "post_max_size" );?></div>
                     <ul>
                         <li>PHP advise you set this value to be slightly greater than the <code>upload_max_filesize</code>.</li>
                     </ul> 
                 </li>
 
-                <li>Look in the Ini file for <code>memory_limit =</code> and set the value to an amount that you want to be the maximum amount of memory in bytes that a script is allowed to allocate. The format for this setting is the number, then the letter 'M': 
+                <li>Look in the Ini file for <code>memory_limit =</code> and set the value to an amount that you want to be the maximum amount of memory in bytes that a script is allowed to allocate. The format for this setting is a number, then the letter 'M': 
                 <div class="info"><?php echo ini_get( "memory_limit" );?></div>
                 </li>
             </ul>

--- a/setup/php_modules_iframe.php
+++ b/setup/php_modules_iframe.php
@@ -30,27 +30,27 @@
 
 	if(ini_get("upload_tmp_dir")==""){
 
-		echo "The directory isn't set, PHP should use a default value, but you may want to set this. <br>";
+		echo "The file upload temporary directory isn't set. PHP should use a default value, but you may want to set this. <br>";
 
 	}else{
 
-		echo "File uploads are set in php.ini to be " . ini_get("upload_tmp_dir") . "<br>";
+		echo "The file upload temporary directory is set in php.ini to be " . ini_get("upload_tmp_dir") . "<br>";
 
 	}
 
-	echo "The maximum uploadedable file size is set in php.ini to be " . ini_get("upload_max_filesize") . "<br>";
+	echo "The maximum uploadable file size is set in php.ini to be " . ini_get("upload_max_filesize") . "<br>";
 	echo "The max post size is set in php.ini to be " . ini_get("post_max_size") . "<br>";
 	echo "The memory limit is set in php.ini to be " . ini_get("memory_limit") . "<br>";
 
-	echo "Checking for MySQL Code<br>";
+	echo "Checking for MySQL code<br>";
 
 	if(function_exists("mysql_connect")){
 
-		echo "MySQL functions exist<Br>";
+		echo "MySQL functions exist<br>";
 
 	}else{
 
-		echo "MySQL functions do not exist<Br>";
+		echo "MySQL functions do not exist<br>";
 
 	}
 
@@ -58,35 +58,35 @@
 
 	if(function_exists("session_start")){
 
-		echo "Sessions exists<Br>";
+		echo "Sessions exists<br>";
 
 	}else{
 
-		echo "Session functions do not exist<Br>";
+		echo "Session functions do not exist<br>";
 
 	}
 
-	echo "Checking for ldap code <br>";
+	echo "Checking for LDAP code<br>";
 
 	if(function_exists("ldap_connect")){
 
-		echo "LDAP functions exists<Br>";
+		echo "LDAP functions exist<br>";
 
 	}else{
 
-		echo "LDAP functions do not exist<Br>";
+		echo "LDAP functions do not exist<br>";
 
 	}
 
-	echo "Checking for mail Zlib <br>";
+	echo "Checking for mail Zlib functions<br>";
 
 	if(function_exists("gzcompress")){
 
-		echo "Zlib function exists<Br>";
+		echo "Zlib functions exist<br>";
 
 	}else{
 
-		echo "Zlib functions do not exist<Br>";
+		echo "Zlib functions do not exist<br>";
 
 	}
 

--- a/setup/php_modules_test.php
+++ b/setup/php_modules_test.php
@@ -26,16 +26,16 @@ $warning=false;
 </h2>
 
 <p>
-    Use your <a href="phpinfo.php" target="_blank">PHP info page</a> to find the 'Loaded Configuration File' (look on the first part of the php info page for the text 'Loaded Configuration File' - the use this path to find the file. Make a copy of it before you start. You can edit this file in notepad, or any text editor. People following the XAMPP path should find that they do not need to make any of these changes to make their system work.
+    Use your <a href="phpinfo.php" target="_blank">PHP info page</a> to find the 'Loaded Configuration File' (look on the first part of the php info page for the text 'Loaded Configuration File' - then use this path to find the file. Make a copy of it before you start. You can edit this file in notepad, or any text editor. People following the XAMPP path should find that they do not need to make any of these changes to make their system work.
 <ol>
     <li><b>The PHP " File uploads" setting</b>
         <ul>
             <li>Look in the Ini file for "file_uploads =" and set the value to be On :<?php if (ini_get("file_uploads") == 1){ echo "<div class=\"ok\">OK</div>";} else {echo "div class=\"error\">Off</div>"; $ok=false;} ?></li>
-            <li>Look in the Ini file for "upload_tmp_dir =" and set the value to a path of your system outside of the area available from the web server (i.e if you are using XAMPP - do not put the temp directory in the HTDOCS folder): <div class="info"><?php echo ini_get("upload_tmp_dir"); ?></div>
+            <li>Look in the Ini file for "upload_tmp_dir =" and set the value to a path on your system outside of the area available from the web server (i.e if you are using XAMPP - do not put the temp directory in the HTDOCS folder): <div class="info"><?php echo ini_get("upload_tmp_dir"); ?></div>
                 <?php if (ini_get("upload_tmp_dir") == "") {echo "<div class=\"warning\">Not set!</div>"; $warning=true;}?></li>
-            <li>Look in the Ini file for "upload_max_filesize =" and set the value to a that you want to be the maximum file size you can upload. The format for the setting is the number, then the letter 'M': <div class="info"><?php echo ini_get("upload_max_filesize");?></div></li>
-            <li>Look in the Ini file for "post_max_size =" and set the value to a that you want to be the maximum file size you can upload (PHP advise you set this value to be slightly greater than the upload_max_filesize. The format for the setting is the number, then the letter 'M': <div class="info"><?php echo ini_get("post_max_size");?></div></li>
-            <li>Look in the Ini file for "memory_limit =" and set the value to a that you want to be the maximum file size you can upload (PHP advise you set this value to be slightly greater than the upload_max_filesize. The format for the setting is the number, then the letter 'M': <div class="info"><?php echo ini_get("memory_limit");?></div></li>
+            <li>Look in the Ini file for "upload_max_filesize =" and set the value to an amount that you want to be the maximum file size you can upload. The format for the setting is a number, then the letter 'M': <div class="info"><?php echo ini_get("upload_max_filesize");?></div></li>
+            <li>Look in the Ini file for "post_max_size =" and set the value to an amount that you want to be the maximum size of post data allowed. (PHP advise you set this value to be slightly greater than the upload_max_filesize.) The format for the setting is a number, then the letter 'M': <div class="info"><?php echo ini_get("post_max_size");?></div></li>
+            <li>Look in the Ini file for "memory_limit =" and set the value to an amount that you want to be the maximum amount of mmemory in bytes that a script is allowed to allocate. The format for the setting is a number, then the letter 'M': <div class="info"><?php echo ini_get("memory_limit");?></div></li>
         </ul>
     </li>
 


### PR DESCRIPTION
During the setup of Xerte 3.5, found some sentences either truncated or slightly wrong grammatically.
In particular for the upload_tmp_dir check I received:

> Look in the Ini file for upload_tmp_dir = and set the value to a path outside of the public area 
> available to visitors to the web server (e.g if you are using XAMPP - you should not put the temp 
> directory in the HTDOCS folder): try changing this setting to
> Not set!

and for the database connection check

> Sorry, the attempt to connect to MySql on the host 127.0.0.1 has failed using account xxx.
> MySQL reports the following error -
(nothing is then shown - the problem was actually caused by SELinux)

Both of these have now been tidied up to make more sense if things are not set or no error message from MySQL is available.