### PR TITLE
Log file changes

### DIFF
--- a/languages/en-GB/management.inc
+++ b/languages/en-GB/management.inc
@@ -36,7 +36,7 @@
 	
 	define("MANAGEMENT_MENUBAR_TEMPLATES","Users projects");
 	
-	define("MANAGEMENT_MENUBAR_ERRORS","Errors");
+	define("MANAGEMENT_MENUBAR_LOGS","Log files");
 	
 	define("MANAGEMENT_MENUBAR_PLAY","Play security");
 	

--- a/languages/en-GB/website_code/php/management/error_list.inc
+++ b/languages/en-GB/website_code/php/management/error_list.inc
@@ -11,7 +11,7 @@
 	 */
 	 
 
-	define("DELETE_VIEW", "View");
+	define("LOGS_VIEW", "Show");
 
 	define("DELETE_ALL_LOGS", "Delete all log files");
 

--- a/languages/en-GB/website_code/php/management/error_list.inc
+++ b/languages/en-GB/website_code/php/management/error_list.inc
@@ -13,6 +13,6 @@
 
 	define("DELETE_VIEW", "View");
 
-	define("DELETE_ALL", "Delete all error logs");
+	define("DELETE_ALL_LOGS", "Delete all log files");
 
 ?>

--- a/languages/en-GB/website_code/php/management/error_list.inc
+++ b/languages/en-GB/website_code/php/management/error_list.inc
@@ -2,7 +2,7 @@
 
 	/**
 	 * 
-	 * management delete english language file
+	 * management log files english language file
 	 *
 	 * @author Patrick Lockley
 	 * @version 1.0

--- a/management.php
+++ b/management.php
@@ -307,8 +307,7 @@ if (empty($_POST["login"]) && empty($_POST["password"])) {
                                     <button type="button" class="xerte_button" onclick="javascript:templates_list();"><i class="fa fa-file-code-o"></i> <?PHP echo MANAGEMENT_MENUBAR_CENTRAL; ?>	</button>
                                     <button type="button" class="xerte_button" onclick="javascript:users_list();"><i class="fa fa-users"></i> <?PHP echo MANAGEMENT_MENUBAR_USERS; ?>	</button>
                                     <button type="button" class="xerte_button" onclick="javascript:user_templates_list();"><i class="fa fa-file-text-o"></i> <?PHP echo MANAGEMENT_MENUBAR_TEMPLATES; ?>	</button>
-                                    <button type="button" class="xerte_button" onclick="javascript:errors_list();"><i class="fa fa-exclamation-triangle
-"></i> <?PHP echo MANAGEMENT_MENUBAR_ERRORS; ?>	</button>
+                                    <button type="button" class="xerte_button" onclick="javascript:errors_list();"><i class="fa fa-exclamation-triangle"></i> <?PHP echo MANAGEMENT_MENUBAR_LOGS; ?>	</button>
                                     <button type="button" class="xerte_button" onclick="javascript:play_security_list();"><i class="fa fa-key"></i> <?PHP echo MANAGEMENT_MENUBAR_PLAY; ?>	</button>
                                     <button type="button" class="xerte_button" onclick="javascript:categories_list();"><i class="fa fa-list-ul"></i> <?PHP echo MANAGEMENT_MENUBAR_CATEGORIES; ?>	</button>
                                     <button type="button" class="xerte_button" onclick="javascript:licenses_list();"><i class="fa fa-cc"></i> <?PHP echo MANAGEMENT_MENUBAR_LICENCES; ?>	</button>

--- a/website_code/php/management/delete_error_list.php
+++ b/website_code/php/management/delete_error_list.php
@@ -28,7 +28,7 @@ if(is_user_admin()){
 
 	$error_file_list = opendir($path);
 	
-	echo "<div style=\"float:left; margin:10px; width:100%; height:30px; position:relative; border-bottom:1px solid #999\">All error logs deleted</div>";
+	echo "<div style=\"float:left; margin:10px; width:100%; height:30px; position:relative; border-bottom:1px solid #999\">All log files deleted</div>";
 
 	while($file = readdir($error_file_list)){
 

--- a/website_code/php/management/error_list.php
+++ b/website_code/php/management/error_list.php
@@ -30,7 +30,7 @@ if(is_user_admin()){
 
     $error_file_list = opendir($path);
 
-    echo "<div style=\"float:left; margin:10px; width:100%; height:30px; position:relative; border-bottom:1px solid #999\"><button type=\"button\" class=\"xerte_button\" onclick=\"javascript:delete_error_logs()\"><i class=\"fa fa-trash-o\"></i> " . DELETE_ALL . "</button></div>";
+    echo "<div style=\"float:left; margin:10px; width:100%; height:30px; position:relative; border-bottom:1px solid #999\"><button type=\"button\" class=\"xerte_button\" onclick=\"javascript:delete_error_logs()\"><i class=\"fa fa-trash-o\"></i> " . DELETE_ALL_LOGS . "</button></div>";
 
     while($file = readdir($error_file_list)){
 
@@ -46,12 +46,12 @@ if(is_user_admin()){
             $query_for_full_name_response = db_query($query_for_full_name, $params);
 		
             if(sizeof($query_for_full_name_response) > 0) { 
-                $row_name =	$query_for_full_name_response[0];
-                echo "<div class=\"template\" id=\"log" . $row_name['login_id'] . "\" savevalue=\"log" . $row_name['login_id'] .  "\"><p>" . $row_name['firstname'] . " " . $row_name['surname'] . " <a href=\"javascript:templates_display('log" . $row_name['login_id'] . "')\">View</a></p></div><div class=\"template_details\" id=\"log" . $row_name['login_id']  . "_child\">";
+                $row_name = $query_for_full_name_response[0];
+                echo "<div class=\"template\" id=\"log" . $row_name['login_id'] . "\" savevalue=\"log" . $row_name['login_id'] .  "\"><p>" . $row_name['firstname'] . " " . $row_name['surname'] . " <button type=\"button\" class=\"xerte_button\" id=\"log" . $row_name['login_id'] . "_btn\" onclick=\"javascript:templates_display('log" . $row_name['login_id'] . "')\">" . LOGS_VIEW . "</button></p></div><div class=\"template_details\" id=\"log" . $row_name['login_id']  . "_child\">";
 
             }else{
 
-                echo "<div class=\"template\" id=\"log" . $user_parameter . "\" savevalue=\"log" . $user_parameter .  "\"><p>" . $user_parameter . " <a href=\"javascript:templates_display('log" . $user_parameter . "')\">" . DELETE_VIEW . "</a></p></div><div class=\"template_details\" id=\"log" . $user_parameter  . "_child\">";
+                echo "<div class=\"template\" id=\"log" . $user_parameter . "\" savevalue=\"log" . $user_parameter .  "\"><p>" . $user_parameter . " <button type=\"button\" class=\"xerte_button\" id=\"log" . $user_parameter . "_btn\" onclick=\"javascript:templates_display('log" . $user_parameter . "')\">" . LOGS_VIEW . "</button></p></div><div class=\"template_details\" id=\"log" . $user_parameter  . "_child\">";
 
             }
 

--- a/website_code/php/management/site_details_management.php
+++ b/website_code/php/management/site_details_management.php
@@ -72,6 +72,9 @@ if(is_user_admin()) {
     }
     if($res!==false && $res2){
 
+        $msg = "Site changes saved by user from " . $_SERVER['REMOTE_ADDR'];
+        receive_message("", "SYSTEM", "MGMT", "Changes saved", $msg);
+
         echo MANAGEMENT_SITE_CHANGES_SUCCESS;
 
     }else{


### PR DESCRIPTION
The current management/admin UI handles all the log files as 'Errors'. The fact that successful events are logged as well, indicates that errors is not really accurate.

This is a series of (initially 4) commits which modifies the UI so that 'Errors' is now shown as 'Log files'. The log files themselves can now be selected by the standard management Show/Hide buttons. (Previously only the grey 'View' button was shown, and remained as 'View' even when the log file was displayed/selected.) The button label to delete all the ('error') log files has been changed, and when it is confirmed to delete the log files the confirmation message says that all the log files have been deleted (not just error logs).

I have made no change to the 'error_log_path' variable, since it is used throughout Xerte and during setup. Ironically it is still somewhat accurate since it is the path to log files where errors are recorded. This is still true. It is just that some other logs files, not relating to errors, are also be present in the directory. So internally, error_log_path may be used for the location of all log files, but to the user/admin the log files are now treated and shown as 'log files' and not just 'error' logs.