### PR TITLE
Log logins logouts etc

### DIFF
--- a/library/Xerte/Authentication/Ldap.php
+++ b/library/Xerte/Authentication/Ldap.php
@@ -227,7 +227,7 @@ class Xerte_Authentication_Ldap extends Xerte_Authentication_Abstract
             }
 
             if ($ldapSearchResult!==false) {
-                _debug("Serach successful, getting results");
+                _debug("Search successful, getting results");
                 $ldapSearchArray = ldap_get_entries($ldapConnection, $ldapSearchResult);
                 if (!$ldapSearchArray or !isset($ldapSearchArray[0])) {
                     _debug("No entries found" . print_r($ldapSearchArray, true));

--- a/logout.php
+++ b/logout.php
@@ -19,6 +19,23 @@
  */
 require_once("config.php");
 
+if (isset($_SESSION['toolkits_logon_id'])) {
+    if ($_SESSION['toolkits_logon_id'] == "site_administrator") {
+        $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+    }
+    else {
+        if (isset($_SESSION['toolkits_logon_username'])) {
+            $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        }
+        else {
+            $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        }
+
+        receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
+    }
+}
+
 $authmech = Xerte_Authentication_Factory::create($xerte_toolkits_site->authentication_method);
 
 if ($authmech->hasLogout())

--- a/logout.php
+++ b/logout.php
@@ -19,21 +19,21 @@
  */
 require_once("config.php");
 
-if (isset($_SESSION['toolkits_logon_id'])) {
-    if ($_SESSION['toolkits_logon_id'] == "site_administrator") {
-        $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+require $xerte_toolkits_site->php_library_path  . "user_library.php";
+
+if (is_user_admin()) {
+    $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+    receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+}
+else {
+    if (isset($_SESSION['toolkits_logon_username'])) {
+        $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
     }
     else {
-        if (isset($_SESSION['toolkits_logon_username'])) {
-            $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        }
-        else {
-            $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        }
-
-        receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
+        $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
     }
+
+    receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
 }
 
 $authmech = Xerte_Authentication_Factory::create($xerte_toolkits_site->authentication_method);

--- a/management.php
+++ b/management.php
@@ -165,6 +165,9 @@ if (empty($_POST["login"]) && empty($_POST["password"])) {
 
         $_SESSION['toolkits_logon_id'] = "site_administrator";
 
+        $msg = "User logged in successfully from " . $_SERVER['REMOTE_ADDR'];
+        receive_message("", "SYSTEM", "MGMT", "Successful login", $msg);
+
         $mysql_id = database_connect("management.php database connect success", "management.php database connect fail");
 
         /*
@@ -328,8 +331,18 @@ if (empty($_POST["login"]) && empty($_POST["password"])) {
     } else {
 
         /*
-         * Wrong password message
+         * Wrong username or password message
          */
+
+        if ($_POST["login"] == $xerte_toolkits_site->admin_username) {
+            $msg = "User attempted to login from " . $_SERVER['REMOTE_ADDR'];
+        }
+        else {
+            $uid = (empty($_POST["login"])) ? 'UNKNOWN' : $_POST["login"];
+            $msg = "User " . $uid . " attempted to login from " . $_SERVER['REMOTE_ADDR'];
+        }
+
+        receive_message("", "SYSTEM", "MGMT", "Failed login", $msg);
 
         mgt_page($xerte_toolkits_site, MANAGEMENT_LOGON_FAIL . " " . MANAGEMENT_NOT_ADMIN_USERNAME);
 

--- a/management.php
+++ b/management.php
@@ -165,7 +165,7 @@ if (empty($_POST["login"]) && empty($_POST["password"])) {
 
         $_SESSION['toolkits_logon_id'] = "site_administrator";
 
-        $msg = "User logged in successfully from " . $_SERVER['REMOTE_ADDR'];
+        $msg = "Admin user logged in successfully from " . $_SERVER['REMOTE_ADDR'];
         receive_message("", "SYSTEM", "MGMT", "Successful login", $msg);
 
         $mysql_id = database_connect("management.php database connect success", "management.php database connect fail");
@@ -335,7 +335,7 @@ if (empty($_POST["login"]) && empty($_POST["password"])) {
          */
 
         if ($_POST["login"] == $xerte_toolkits_site->admin_username) {
-            $msg = "User attempted to login from " . $_SERVER['REMOTE_ADDR'];
+            $msg = "Admin user attempted to login from " . $_SERVER['REMOTE_ADDR'];
         }
         else {
             $uid = (empty($_POST["login"])) ? 'UNKNOWN' : $_POST["login"];

--- a/website_code/php/error_library.php
+++ b/website_code/php/error_library.php
@@ -86,53 +86,59 @@ function write_message($user_name, $type, $level, $subject, $content){
     }
 
     /*
-     * Get the log file contents (a series of HTML paragraphs separated by *)
+     * Login/logout and management entries should not get logged to any other log files but their own.
      */
+
+    if ($level != "LOGINS" && $level != "MGMT") {
+        /*
+         * Get the log file contents (a series of HTML paragraphs separated by *)
+         */
 
 	$error_string = '';
 
-    if(file_exists($xerte_toolkits_site->error_log_path . $user_name . ".log")){
+        if(file_exists($xerte_toolkits_site->error_log_path . $user_name . ".log")){
 
-        $error_string = file_get_contents($xerte_toolkits_site->error_log_path . $user_name . ".log");
+            $error_string = file_get_contents($xerte_toolkits_site->error_log_path . $user_name . ".log");
 
-    }
+        }
 
-    $error_array = explode("*",$error_string);
+        $error_array = explode("*",$error_string);
 
-    /*
-     * If the error log is bigger than the maximum size, remove a section
-     */
+        /*
+         * If the error log is bigger than the maximum size, remove a section
+         */
 
-    if(count($error_array)>$xerte_toolkits_site->max_error_size){
+        if(count($error_array)>$xerte_toolkits_site->max_error_size){
 
-        array_splice($error_array,0,1);
+            array_splice($error_array,0,1);
 
-    }
+        }
 
-    /*
-     * If the error log is bigger than the maximum size, remove a section
-     */
+        /*
+         * If the error log is bigger than the maximum size, remove a section
+         */
 
-    if(file_exists($xerte_toolkits_site->error_log_path . $user_name . ".log")){
+        if(file_exists($xerte_toolkits_site->error_log_path . $user_name . ".log")){
 
-        $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $user_name . ".log" , "w");
+            $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $user_name . ".log" , "w");
 
-        $string = implode("*", $error_array) . "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
+            $string = implode("*", $error_array) . "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
 
-        fwrite($error_message_handle, $string);
+            fwrite($error_message_handle, $string);
 
-        fclose($error_message_handle);
+            fclose($error_message_handle);
 
-    }else{
+        }else{
 
-        $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $user_name . ".log" , "w");
+            $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $user_name . ".log" , "w");
 
-        $string = "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
+            $string = "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
 
-        fwrite($error_message_handle, $string);
+            fwrite($error_message_handle, $string);
 
-        fclose($error_message_handle);
+            fclose($error_message_handle);
 
+        }
     }
 
 
@@ -140,7 +146,7 @@ function write_message($user_name, $type, $level, $subject, $content){
      * Make an error log file per level as well
      */
 
-	$error_string = '';
+    $error_string = '';
 
     if(file_exists($xerte_toolkits_site->error_log_path . $level . ".log")){
 
@@ -156,11 +162,13 @@ function write_message($user_name, $type, $level, $subject, $content){
 
     }
 
+    $red = ($subject == "Failed login") ? " style='color:#FF0000;'" : "";
+
     if(file_exists($xerte_toolkits_site->error_log_path . $level . ".log")){
 
         $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $level . ".log" , "w");
 
-        $string = implode("*", $error_array) . "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
+        $string = implode("*", $error_array) . "<p" . $red . ">" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
 
         fwrite($error_message_handle, $string);
 
@@ -170,7 +178,7 @@ function write_message($user_name, $type, $level, $subject, $content){
 
         $error_message_handle = fopen($xerte_toolkits_site->error_log_path . $level . ".log" , "w");
 
-        $string = "<p>" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
+        $string = "<p" . $red . ">" . date("G:i:s - d/m/Y") . " " . $level . "<Br>" . $subject . "<Br>" . $content . "</p>*";
 
         fwrite($error_message_handle, $string);
 

--- a/website_code/php/error_library.php
+++ b/website_code/php/error_library.php
@@ -40,6 +40,12 @@ function receive_message($user_name, $type, $level, $subject, $content){
 
     }
 
+    if($user_name==""){
+
+        $user_name="UNKNOWN";
+
+    }
+
     /*
      * If error log message turned on, create an error log
      */
@@ -78,12 +84,6 @@ function receive_message($user_name, $type, $level, $subject, $content){
 function write_message($user_name, $type, $level, $subject, $content){
 
     global $xerte_toolkits_site;
-
-    if($user_name==""){
-
-        $user_name="UNKNOWN";
-
-    }
 
     /*
      * Login/logout and management entries should not get logged to any other log files but their own.

--- a/website_code/php/login_library.php
+++ b/website_code/php/login_library.php
@@ -361,6 +361,9 @@ function login_processing($exit = true) {
 
     if ($exit === true) {
       if (!$success || !empty($errors)) {
+        $msg = "User '" . $_POST['login'] . "' attempted to login from " . $_SERVER['REMOTE_ADDR'];
+        receive_message("", "SYSTEM", "LOGINS", "Failed login", $msg);
+
         login_form($errors, $xerte_toolkits_site);
         exit(0);
       }

--- a/website_code/php/login_library.php
+++ b/website_code/php/login_library.php
@@ -412,4 +412,7 @@ function login_processing2($firstname = false, $surname = false, $username = fal
 
     update_user_logon_time();
   }
+
+  $msg = "User " . $_SESSION['toolkits_logon_username'] . " logged in successfully from " . $_SERVER['REMOTE_ADDR'];
+  receive_message($_SESSION['toolkits_logon_username'], "SYSTEM", "LOGINS", "Successful login", $msg);
 }

--- a/website_code/php/login_library.php
+++ b/website_code/php/login_library.php
@@ -361,8 +361,10 @@ function login_processing($exit = true) {
 
     if ($exit === true) {
       if (!$success || !empty($errors)) {
-        $msg = "User '" . $_POST['login'] . "' attempted to login from " . $_SERVER['REMOTE_ADDR'];
-        receive_message("", "SYSTEM", "LOGINS", "Failed login", $msg);
+        if (in_array(INDEX_USERNAME_AND_PASSWORD_EMPTY, $errors) == false) {
+          $msg = "User '" . $_POST['login'] . "' attempted to login from " . $_SERVER['REMOTE_ADDR'];
+          receive_message("", "SYSTEM", "LOGINS", "Failed login", $msg);
+        }
 
         login_form($errors, $xerte_toolkits_site);
         exit(0);

--- a/website_code/php/logout.php
+++ b/website_code/php/logout.php
@@ -28,21 +28,21 @@
 
 require_once(dirname(__FILE__) . '/../../config.php');
 
-if (isset($_SESSION['toolkits_logon_id'])) {
-    if ($_SESSION['toolkits_logon_id'] == "site_administrator") {
-        $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+require "user_library.php";
+
+if (is_user_admin()) {
+    $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+    receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+}
+else {
+    if (isset($_SESSION['toolkits_logon_username'])) {
+        $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
     }
     else {
-        if (isset($_SESSION['toolkits_logon_username'])) {
-            $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        }
-        else {
-            $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
-        }
-
-        receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
+        $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
     }
+
+    receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
 }
 
 $authmech = Xerte_Authentication_Factory::create($xerte_toolkits_site->authentication_method);

--- a/website_code/php/logout.php
+++ b/website_code/php/logout.php
@@ -28,6 +28,23 @@
 
 require_once(dirname(__FILE__) . '/../../config.php');
 
+if (isset($_SESSION['toolkits_logon_id'])) {
+    if ($_SESSION['toolkits_logon_id'] == "site_administrator") {
+        $msg = "Admin user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        receive_message("", "SYSTEM", "MGMT", "Logout", $msg);
+    }
+    else {
+        if (isset($_SESSION['toolkits_logon_username'])) {
+            $msg = "User " . $_SESSION['toolkits_logon_username'] . " (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        }
+        else {
+            $msg = "Unknown user (from " . $_SERVER['REMOTE_ADDR'] . ") has logged out";
+        }
+
+        receive_message("", "SYSTEM", "LOGINS", "Logout", $msg);
+    }
+}
+
 $authmech = Xerte_Authentication_Factory::create($xerte_toolkits_site->authentication_method);
 
 if ($authmech->hasLogout())

--- a/website_code/php/management/play_security_management.php
+++ b/website_code/php/management/play_security_management.php
@@ -31,6 +31,9 @@ if(is_user_admin()){
     $res = db_query($query, array($_POST['security'], $_POST['data'], $_POST['info'] , $_POST['play_id'] ));
 
     if($res) {
+        $msg = "Play security changes saved by user from " . $_SERVER['REMOTE_ADDR'];
+        receive_message("", "SYSTEM", "MGMT", "Changes saved", $msg);
+
         echo MANAGEMENT_PLAY_SUCCESS;
     }else{
         echo MANAGEMENT_PLAY_FAIL;

--- a/website_code/php/management/template_details_management.php
+++ b/website_code/php/management/template_details_management.php
@@ -42,6 +42,9 @@ if(is_user_admin()){
 
 
 	if($res){
+		$msg = "Template changes saved by user from " . $_SERVER['REMOTE_ADDR'];
+		receive_message("", "SYSTEM", "MGMT", "Changes saved", $msg);
+
 		echo TEMPLATE_CHANGE_SUCCESS;
 	}else{
 		echo TEMPLATE_CHANGE_FAIL . " " . mysql_error();

--- a/website_code/php/management/user_details_management.php
+++ b/website_code/php/management/user_details_management.php
@@ -32,6 +32,9 @@ if(is_user_admin()){
 
     $res =db_query($query, $params);
     if($res) {
+        $msg = "User changes saved by user from " . $_SERVER['REMOTE_ADDR'];
+        receive_message("", "SYSTEM", "MGMT", "Changes saved", $msg);
+
         echo USERS_UPDATE_SUCCESS;
     }else{
         echo USERS_UPDATE_FAIL;

--- a/website_code/php/user_library.php
+++ b/website_code/php/user_library.php
@@ -40,11 +40,11 @@ function check_if_first_time($username){
 
 /**
  *
- * Function get user id
- * get the user's database ID
+ * Function get user info
+ * get the user's database info
  * @author Patrick Lockley
  * @version 1.0
- * @return number - The user's database id
+ * @return array - items of user info
  * @package
  */
 function get_user_info(){
@@ -289,7 +289,7 @@ function get_user_root_folder(){
  * Is this user set as an administrator
  * @author Patrick Lockley
  * @version 1.0
- * @return bool - Is this the user an administrator
+ * @return bool - Is this user an administrator?
  * @package
  */
 function is_user_admin(){


### PR DESCRIPTION
I think this is the last of the commits we have for log files. Basically we have tried to do 2 things: 1) Log config changes to a MGMT log file (for security we would want to know when changes were made and ideally by whom); (2) log user login attempts and logouts to a separate LOGINS log file. We can then tie up when a user was logged in if required. Failed logins are shown in red. This should make it easier to spot repeated login attempts. For the admin user the username is not recorded. For all users the IP address is recorded.
All other user activity goes to the log file for the specific user.