### PR TITLE
Ldap passwd fix

### DIFF
--- a/website_code/php/management/site.php
+++ b/website_code/php/management/site.php
@@ -182,7 +182,7 @@ if(is_user_admin()){
 
     echo "<p>" . MANAGEMENT_SITE_LDAP_PORT . "<form><textarea id=\"ldap_port\">" . $row['ldap_port'] . "</textarea></form></p>";
 
-    echo "<p>" . MANAGEMENT_SITE_LDAP_PASSWORD . "<form><textarea id=\"bind_pwd\">" . $row['bind_pwd'] . "</textarea></form></p>";
+    echo "<p>" . MANAGEMENT_SITE_LDAP_PASSWORD . "<form><textarea id=\"bind_pwd\">" . htmlspecialchars($row['bind_pwd']) . "</textarea></form></p>";
 
     echo "<p>" . MANAGEMENT_SITE_LDAP_BASE . "<form><textarea id=\"base_dn\">" . $row['basedn'] . "</textarea></form></p>";
 

--- a/website_code/scripts/management.js
+++ b/website_code/scripts/management.js
@@ -397,8 +397,13 @@ function update_site(){
 		xmlHttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 
 		copyright = document.getElementById("copyright").value;
-
 		copyright = copyright.split("�").join("AAA");
+
+		// Some elements, such as passwords, may contain HTML-interpreted characters,
+		// such as '&'. These elements need to be encoded before being POST'd.
+
+		var bpwd = document.getElementById("bind_pwd").value;
+		bpwd = encodeURIComponent(bpwd);
 
 		xmlHttp.send('site_url=' + document.getElementById("site_url").value + 
 					 '&apache=' + document.getElementById("apache").value + 
@@ -430,7 +435,7 @@ function update_site(){
 					 '&authentication_method=' + document.getElementById("authentication_method").value + 
 					 '&ldap_host=' + document.getElementById("ldap_host").value	+ 
 					 '&ldap_port=' + document.getElementById("ldap_port").value + 
-					 '&bind_pwd=' + document.getElementById("bind_pwd").value + 
+					 '&bind_pwd=' + bpwd + 
 					 '&base_dn=' + document.getElementById("base_dn").value + 
 					 '&bind_dn=' + document.getElementById("bind_dn").value + 
 					 '&flash_save_path=' + document.getElementById("flash_save_path").value + 


### PR DESCRIPTION
The password used with the LDAP bind account could contain any character - including those interpreted by HTML such as '&'. At the moment a password with '&' in it will be truncated, so LDAP access will always fail. (It happened with us, and took a while to work out what the problem was.)
2 commits here - one encodes the password (in management.js) before it is POSTed. Without this the '&' gets interpreted on the receiving end. I tried putting the encoding all inline, but javascript didn't like that. So I had to create a separate variable.
Second commit is that the password should be shown as text, not HTML interpreted, in the administrator interface.