### PR TITLE
Allow the copyright text to include the '&copy;' HTML entity.

### DIFF
--- a/website_code/php/management/site.php
+++ b/website_code/php/management/site.php
@@ -74,7 +74,7 @@ if(is_user_admin()){
 
     echo "<p>" . MANAGEMENT_SITE_POD_TWO . "<form><textarea id=\"pod_two\">" . base64_decode($row['pod_two']) . "</textarea></form></p>";	
 
-    echo "<p>" . MANAGEMENT_SITE_COPYRIGHT . "<form><textarea id=\"copyright\">" . $row['copyright'] . "</textarea></form></p>";	
+    echo "<p>" . MANAGEMENT_SITE_COPYRIGHT . "<form><textarea id=\"copyright\">" . htmlspecialchars($row['copyright']) . "</textarea></form></p>";
 
     echo "<p>" . MANAGEMENT_SITE_DEMONSTRATION . "<form><textarea id=\"demonstration_page\">" . $row['demonstration_page'] . "</textarea></form></p>";	
 

--- a/website_code/scripts/management.js
+++ b/website_code/scripts/management.js
@@ -397,8 +397,10 @@ function update_site(){
 		xmlHttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 
 		copyright = document.getElementById("copyright").value;
-
 		copyright = copyright.split("�").join("AAA");
+
+		var cpyright = document.getElementById("copyright").value;
+		cpyright = encodeURIComponent(cpyright);
 
 		xmlHttp.send('site_url=' + document.getElementById("site_url").value + 
 					 '&apache=' + document.getElementById("apache").value + 
@@ -412,7 +414,7 @@ function update_site(){
                      '&news_text=' + document.getElementById("news_text").value +
 					 '&pod_one=' + document.getElementById("pod_one").value + 
 					 '&pod_two=' + document.getElementById("pod_two").value + 
-					 '&copyright=' + document.getElementById("copyright").value + 
+					 '&copyright=' + cpyright + 
 					 '&demonstration_page=' + document.getElementById("demonstration_page").value + 
 					 '&form_string=' + document.getElementById("form_string").value + 
 					 '&peer_form_string=' + document.getElementById("peer_form_string").value + 


### PR DESCRIPTION
This is basically the same as the LDAP password fix, in that the copyright text could include an '&' symbol - typically for use with '&copy;'. The symbol will be displayed on the page correctly, but in the administrator interface will be shown as text.
I see that the code in 'website_code/scripts/management.js' does something with replacing some 'thing' with 'AAA'. Not sure what the 'thing' but it looks like some encoding of some sort. Then on the receiving end in 'website_code/php/management/site_details_management.php' the AAA is replaced by '&copy;'.
I have left that code alone, but with this commit is may not be required anymore?