### PR TITLE
Admin pwd fix

### DIFF
--- a/setup/page3.php
+++ b/setup/page3.php
@@ -66,7 +66,7 @@ echo "<p>The integration config path (for use if integrating with other systems 
 
 echo "<p>The admin username is <textarea name=\"admin_username\">" . $_POST['account'] . "</textarea></p>";
 
-echo "<p>The admin password is <textarea name=\"admin_password\">" . $_POST['password'] . "</textarea></p>";	
+echo "<p>The admin password is <textarea name=\"admin_password\">" . htmlspecialchars($_POST['password']) . "</textarea></p>";
 
 echo "<p>The allowed upload types for the Media and quota page are <textarea name=\"mimetypes\">text/xml,application/msword,application/x-shockwave-flash,image/jpeg,image/pjpeg,image/png,image/gif,image/x-png,audio/mpeg,application/vnd.ms-excel,application/pdf,application/vnd.ms-powerpoint,video/x-ms-wmv,text/html,video/mp4,video/avi,audio/wav,text/plain,video/quicktime,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation</textarea>
     </p>";	

--- a/setup/page_password.php
+++ b/setup/page_password.php
@@ -108,6 +108,8 @@ if ($success)
                 if(document.getElementById('account').value==''||document.getElementById('password').value==''){
                     alert('Please set a username and password');
                     return false;
+                } else {
+                    document.getElementById('password').value = encodeURIComponent(document.getElementById('password').value);
                 }
                 return true;" enctype="multipart/form-data">
         <label for="account">Admin account name</label><br /><br /><input type="text" width="100" name="account" id="account" /><br /><br />

--- a/website_code/php/management/site.php
+++ b/website_code/php/management/site.php
@@ -102,7 +102,7 @@ if(is_user_admin()){
     echo "<p>" . MANAGEMENT_SITE_ADMIN_USER . "<form><textarea id=\"admin_username\">" . $row['admin_username'] . "</textarea></form>
         </p>";	
 
-    echo "<p>" . MANAGEMENT_SITE_ADMIN_PASSWORD . "<form><textarea id=\"admin_password\">" . $row['admin_password'] . "</textarea></form>
+    echo "<p>" . MANAGEMENT_SITE_ADMIN_PASSWORD . "<form><textarea id=\"admin_password\">" . htmlspecialchars($row['admin_password']) . "</textarea></form>
         </p>";	
 
     echo "</div>";

--- a/website_code/scripts/management.js
+++ b/website_code/scripts/management.js
@@ -452,7 +452,7 @@ function update_site(){
 					 '&LDAP_filter=' + document.getElementById("LDAP_filter").value + 
 					 '&integration_config_path=' + document.getElementById("integration_config_path").value + 
 					 '&admin_username=' + document.getElementById("admin_username").value + 
-					 '&admin_password=' + document.getElementById("admin_password").value +
+					 '&admin_password=' + encodeURIComponent(document.getElementById("admin_password").value) +
 					 '&site_xapi_endpoint=' + document.getElementById("site_xapi_endpoint").value +
 					 '&site_xapi_key=' + document.getElementById("site_xapi_key").value +
 					 '&site_xapi_secret=' + document.getElementById("site_xapi_secret").value);


### PR DESCRIPTION
This is basically the same as the LDAP password fix. The passwd could contain HTML characters (e.g. '&'), and these should not be interpreted when displaying the password.
The password can be set during Xerte installation. This has been catered for but not tested.