### PR TITLE
PHP file uploads should check for PHP case-independently.

### DIFF
--- a/website_code/php/import/fileupload.php
+++ b/website_code/php/import/fileupload.php
@@ -27,7 +27,7 @@ if(in_array($_FILES['filenameuploaded']['type'],$xerte_toolkits_site->mimetypes)
 
         $php_check = file_get_contents($_FILES['filenameuploaded']['tmp_name']);
 
-        if(!strpos($php_check,"<?PHP")){
+        if(!stripos($php_check,"<?PHP")){
 
             $new_file_name = $_POST['mediapath'] . $_FILES['filenameuploaded']['name'];
 


### PR DESCRIPTION
The 'stripos' function is supported in PHP 5 and 7. The Xerte FAQ says that the minimum spec for PHP should be 5 (http://www.xerte.org.uk/index.php?option=com_faqbook&view=category&id=138&Itemid=567&lang=en]). So it should be safe to use this function.
However, if it is felt that it may cause problems, then perhaps the check should become:

`if(!strpos($php_check,"<?PHP") && !strpos($php_check,"<?php")){`