### PR TITLE
Non-windows files do not require a file extension.

### DIFF
--- a/library/Xerte/Validate/FileExtension.php
+++ b/library/Xerte/Validate/FileExtension.php
@@ -41,10 +41,16 @@ class Xerte_Validate_FileExtension
         _debug($blacklist);
         _debug($extension);
 
-        if (empty($extension)) {
-            _debug("File extension not found for '$filename'.");
-            $this->messages['NO_EXTENSION'] = "File extension not found.";
-            return false;
+        if (strncasecmp(PHP_OS, 'Win', 3) == 0) {
+            /* This is for Windows filenames. */
+            if (empty($extension)) {
+                _debug("File extension not found for '$filename'.");
+                $this->messages['NO_EXTENSION'] = "File extension not found.";
+                return false;
+            }
+        }
+        elseif (!strlen($extension)) {
+            return true;
         }
 
         if (in_array($extension, $blacklist)) {


### PR DESCRIPTION
This commit stems from a message I sent to the forum: []http://www.xerte.org.uk/index.php?option=com_kunena&view=topic&catid=4&id=928&Itemid=759&lang=en#3048
A user uploading a project from a Linux PC to a Linux Xerte server, may well have files with no extension on them.