### PR TITLE
Allow the admin user to publish and export projects. Fix for #689

### DIFF
--- a/editor/upload.php
+++ b/editor/upload.php
@@ -72,8 +72,9 @@ class ExSimpleXMLElement extends SimpleXMLElement
     }
 }
 
-if (!isset($_SESSION['toolkits_logon_username']))
+if (!isset($_SESSION['toolkits_logon_username']) && !is_user_admin())
 {
+    _debug("Session is invalid or expired");
     die("Session is invalid or expired");
 }
 

--- a/website_code/php/scorm/export.php
+++ b/website_code/php/scorm/export.php
@@ -27,6 +27,7 @@
  * @package
  */
 require_once("../../../config.php");
+require_once("../user_library.php");
 include "../template_status.php";
 $prefix = $xerte_toolkits_site->database_table_prefix;
 


### PR DESCRIPTION
This is for part 1 of the issue #689. The admin user does not have the logon username variable set, so we have to explicitly check for the sysadmin.
Ironically the hard part (for me) was what to do with the 'die' statement. I couldn't figure out how to change it so the popup gave an actual error message rather than just 'error'. I'm assuming 'error' is the browser javascript default message. I tried wrapping it in html/javascript but that made no difference. I don't understand the context that the code is being run in, so that is probably why usual tricks are not working. Using exit rather than die stopped the popup from appearing, and I think that would be confusing for the user. (They click on 'Publish', it fails but there is no error message of any kind.)
I have included an _debug statement so that at least the error gets logged.

Took a quick look at part 2 of the issue (exporting projects), and it seems to just be a missing 'require' file. So added the commit for that too.