### PR TITLE
Adding mysql fields - minor changes to '_db_add_field'

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -59,7 +59,18 @@ function _db_field_exists($table, $field) {
 function _db_add_field($table, $field, $fieldtype, $default, $after) {
     $table = table_by_key($table);
     if(! _db_field_exists($table, $field)) {
-        $query = "ALTER TABLE $table ADD COLUMN $field $fieldtype DEFAULT '$default' AFTER $after";
+        $fieldtype = strtoupper($fieldtype);
+        $query = "ALTER TABLE $table ADD COLUMN $field $fieldtype";
+
+        /* TEXT and BLOB types cannot have a default. */
+        if ($fieldtype != 'TEXT' && $fieldtype != 'BLOB') {
+            $query .= " DEFAULT '$default'";
+        }
+
+        if ($after) {
+            $query .= " AFTER $after";
+        }
+
         return db_query($query);
     } else { 
         printdebug ("field already exists: $table.$field");


### PR DESCRIPTION
The commit has two changes:
1) If the BLOB or TEXT mysql field type is given, then no DEFAULT value is added to the DB query.
2) If the 'after' field to the '_db_add_field' function is not specified, then no 'AFTER' option is included in the DB query. (Basically, if it's not specified (or rather is null), then add the field to the end of the table. This saves trying to work out the name of the last field.)