### PR TITLE
Fix for issue #699

### DIFF
--- a/setup/page2.php
+++ b/setup/page2.php
@@ -81,7 +81,7 @@ if ( !isset($_POST['database_created']) )
             {
                 $query = $temp[$x++];
 
-                if ( $query !="" ) 
+                if ( strlen($query) > 1 ) 
                 {
                     $ok = $xot_setup->database->runQuery( $query );
 


### PR DESCRIPTION
Recently modifying 'setup/basic.sql' caused a newline to be added to the file. When 'explode' is used to create an array of DB queries, the last query becomes just the newline - which db_query doesn't like.
Previously a check was made that the line is not empty (""). This commit changes that to check that the line length is more than 1 character.
An alternative fix would be to use (on line 84):
`if ( $query !=""  && $query != "\n")`