### PR TITLE
Editor import merge fix.

### DIFF
--- a/editor/importpages/merge.php
+++ b/editor/importpages/merge.php
@@ -87,7 +87,7 @@ function merge_pages_to_project($source_project_id, $source_pages, $target_proje
 			{
 				$newId = "PG" . (substr($newId, 2)+1);
 			}
-			array_push($newId, $bannedLinkIDs);
+			array_push($bannedLinkIDs, $newId);
 			$mapping[$oldId] = $newId;
 				
 		}else{


### PR DESCRIPTION
Noticed the following errors:
======
PHP Warning:  array_push() expects parameter 1 to be array, string given in /var/www/html/xerte-3.5/editor/importpages/merge.php on line 90
======

It looks like the arguments to the array_push call were the wrong way round. This commits swaps them around.