### PR TITLE
Add a spinner when uploading a project zip file.

### DIFF
--- a/languages/en-GB/website_code/scripts/workspaceproperties_tab.js
+++ b/languages/en-GB/website_code/scripts/workspaceproperties_tab.js
@@ -9,5 +9,6 @@
 
 	var WORKSPACE_IMPORT = "Import";
 	var WORKSPACE_UPLOAD = "Upload";
+	var WORKSPACE_UPLOADING = "Uploading...";
     	var WORKSPACE_NEW_PROJECTNAME = "New project name";
     	var WORKSPACE_API = "API";

--- a/website_code/scripts/import.js
+++ b/website_code/scripts/import.js
@@ -94,6 +94,16 @@ function iframe_check(){
 
 	if(window["upload_iframe"].document.body.innerHTML!=""){
 
+	    var string = document.getElementById("submitbutton").innerHTML;
+
+	    if(string.indexOf('fa-spin') != -1) {
+		// We have received a reply, so replace the spinner with the default upload button icon.
+		string = string.replace('<i class="fa fa-spinner fa-spin"></i> ' + WORKSPACE_UPLOADING, '<i class="fa fa-upload"></i> ' + WORKSPACE_UPLOAD);
+		document.getElementById('submitbutton').innerHTML = string;
+		document.getElementById('submitbutton').disabled = false;
+//		document.getElementById('importpopup').reset();
+	    }
+
 		if(window["upload_iframe"].document.body.innerHTML.indexOf("****")!=-1){
 
 			clearInterval(iframe_interval);

--- a/website_code/scripts/workspaceproperties_tab.js
+++ b/website_code/scripts/workspaceproperties_tab.js
@@ -296,6 +296,13 @@ function import_templates_template(){
 
 	document.getElementById("dynamic_area").innerHTML = '<p class="header"><span>' + WORKSPACE_IMPORT + '</span></p><p><form target="upload_iframe" method="post" onsubmit="javascript:iframe_check_initialise();" enctype="multipart/form-data" id="importpopup" name="importform" action="website_code/php/import/import.php" ><input name="filenameuploaded" type="file" /><br /><br />' + WORKSPACE_NEW_PROJECTNAME + '<br /><br /><input name="templatename" type="text" onkeyup="new_template_name()" /><br /><span id="namewrong"></span><br /><button id="submitbutton" type="submit" name="submitBtn" onsubmit="javascript:iframe_check_initialise();" class="xerte_button"><i class="fa fa-upload"></i> ' + WORKSPACE_UPLOAD + '</button></form></p>';
 
+	$('#submitbutton').click(function() {
+		this.disabled = true;
+		// Replace the upload button icon with a spinner.
+		var string = this.innerHTML;
+		string = string.replace('<i class="fa fa-upload"></i> ' + WORKSPACE_UPLOAD, '<i class="fa fa-spinner fa-spin"></i> ' + WORKSPACE_UPLOADING);
+		this.innerHTML = string;
+	});
 }
 
 /**


### PR DESCRIPTION
The ClamAV check in particular can take some time  (unless clamdscan is used). These commits add a spinner to show that something is happening. It changes the 'Upload' button icon into 'Uploading...' and adds a small spinner next to it.
The upload icon can be found by logging in; highlight 'Workspace'; click on 'Properties' icon above; then click on 'Import' tab.