### PR TITLE
Ensure the file checks return the correct error if no file was selected.

### DIFF
--- a/library/Xerte/Validate/FileExtension.php
+++ b/library/Xerte/Validate/FileExtension.php
@@ -34,6 +34,11 @@ class Xerte_Validate_FileExtension
     {
         $this->messages = array();
 
+        if (!$filename) {
+            $this->messages['FILE_NO_FILE'] = "No file selected";
+            return false;
+        }
+
         $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
         if (strncasecmp(PHP_OS, 'Win', 3) == 0) {

--- a/library/Xerte/Validate/FileMimeType.php
+++ b/library/Xerte/Validate/FileMimeType.php
@@ -40,8 +40,12 @@ class Xerte_Validate_FileMimeType {
      */
     public function isValid($file_name) {
         $this->messages = array();
+
         if(self::canRun()) {
-            if(file_exists($file_name)) {
+            if(!$file_name) {
+                $this->messages['FILE_NO_FILE'] = "No file selected";
+            }
+            elseif(file_exists($file_name)) {
                 $mime_type = mime_content_type($file_name);
                 if(in_array($mime_type, self::$allowableMimeTypeList)) {
                     return true;

--- a/plugins/file_uploading-extension-check.php
+++ b/plugins/file_uploading-extension-check.php
@@ -56,10 +56,15 @@ function filter_by_extension_name() {
 
     foreach($files['file_name'] as $key => $file) {
         $validator = new Xerte_Validate_FileExtension();
+
         if(!$validator->isValid($file)) {
             $real_path = $files['temp_name'][$key];
 
-            if (file_exists($real_path)) {
+            if (!$file) {
+                _debug("File extension check failed - no file selected");
+                error_log("File extension check failed - no file selected");
+            }
+            elseif (file_exists($real_path)) {
                 _debug("Blacklisted file extension of uploaded file - $file");
                 error_log("Blacklisted file extension found for file $file ($real_path)");
 

--- a/plugins/file_uploading-mimetype.php
+++ b/plugins/file_uploading-mimetype.php
@@ -55,20 +55,24 @@ function filter_by_mimetype() {
     }
 
     foreach($files['temp_name'] as $key => $file) {
-        $validator = new Xerte_Validate_FileMimeType();
-        if(!$validator->isValid($file)) {
-	    if (file_exists($file)) {
+	$validator = new Xerte_Validate_FileMimeType();
+	if(!$validator->isValid($file)) {
+	    if (!$file) {
+		_debug("Mime check failed - no file selected");
+		error_log("Mime check failed - no file selected");
+	    }
+	    elseif (file_exists($file)) {
 		_debug("Mime check of {$files['file_name'][$key]} failed.");
 		error_log("Mime check of {$files['file_name'][$key]} ($file) failed");
 
-                unlink($file);
+		unlink($file);
 	    }
 	    else {
 		_debug("Mime check of {$files['file_name'][$key]} failed - file does not exist");
 		error_log("Mime check of {$files['file_name'][$key]} ($file) failed - file does not exist");
 	    }
 
-            $last_file_check_error = $validator->GetMessages();
+	    $last_file_check_error = $validator->GetMessages();
 
 	    return false;
 	}


### PR DESCRIPTION
If a user selected no files for uploading then a file not found error was given. These commits ensure that a 'no file selected' error is shown instead.