### PR TITLE
Remove error when deleting multiple projects.

### DIFF
--- a/website_code/scripts/template_management.js
+++ b/website_code/scripts/template_management.js
@@ -1009,7 +1009,11 @@ function remove_this(){
             for(var i=0; i<ids.length; i++)
             {
                 var node = workspace.nodes[ids[i]];
-                if(node.xot_type=="file"){
+
+                if (ids[i] == workspace.workspace_id) {
+                    continue;
+                }
+                else if(node.xot_type=="file"){
                     if(node.parent==workspace.recyclebin_id){
                         var answer = confirm(DELETE_PERMENANT_PROMPT + " - " + node.text);
                         if(answer){


### PR DESCRIPTION
When deleting multiple projects, the projects are deleted but then a final error is popped up saying 'Sorry you cannot delete a folder that has projects in it. Please empty the folder first'.
It seems that the internal list produced includes the 'Workspace' folder, and this cannot be deleted.
The commit just checks for the workspace folder, and skips over it.

Deleting a single project shows no such problem.
Selecting the 'Recycle Bin' folder and clicking on the 'Delete' icon above will prompt if the recycle bin is to be emptied. This works fine, and shows no popup error.

To test the error, log in, then:
highlight multiple projects (using the shift key) from the Workspace folder, then click on the 'Delete' icon near the top;
click through the prompts confirming that the projects are to be deleted;
click on the '+' sign next to the recycle bin folder, to show the projects in there;
highlight more than one project (again using the shift key), and click on the 'Delete' icon again;
again click through the confirmation popups for the projects;
a final popup will show the error message quoted above.
