### PR TITLE
Trim space from both ends of Fill in Blank answer

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -397,10 +397,7 @@
 						var $this = $(this);
 
 						setTimeout(function() {
-							currvalue = $this.val();
-							if (!casesensitive) {
-								currvalue = $this.val().toLowerCase();
-							}
+							var currvalue = !casesensitive ? $this.val().trim().toLowerCase() : $this.val().trim();
 							if (answerData[$this.data("index")].indexOf(currvalue) != -1) { // correct
 								$this
 									.attr("readonly", "readonly")
@@ -514,9 +511,9 @@
 					})
 					//.attr("tabindex",tabIndex) // **
 					.click(function() {
-						 $targetHolder.find("input").each(function() {
+						$targetHolder.find("input").each(function() {
 							var $this = $(this),
-								currvalue = !casesensitive ? $this.val().toLowerCase() : $this.val();
+								currvalue = !casesensitive ? $this.val().trim().toLowerCase() : $this.val().trim();
 							
 							if (answerData[$this.data("index")].indexOf(currvalue) != -1) {
 								$this.attr("readonly", "readonly");
@@ -1006,7 +1003,7 @@
 				
                 $targetHolder.find("input").each(function() {
                     var $this = $(this),
-                        currvalue = !casesensitive ? $this.val().toLowerCase() : $this.val();
+                        currvalue = !casesensitive ? $this.val().trim().toLowerCase() : $this.val().trim();
                     var feedback = "Incorrect"
                     var correct = false;
                     var answer = currvalue;


### PR DESCRIPTION
Trim whitespace from both ends of the *Fill in Blank* answer string. This will handle an answer as correct if the end user accidentally starts with typing a space for example. 
Also made assignment of `currvalue` identical throughout this script. This made `currvalue` local to the `setTimeout` function. Or should the `currvalue` declared on line 34 be used everywhere?

See [Mozilla trim() method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim)