### PR TITLE
No autocapitalize for Fill in Blank input for iOS

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -186,7 +186,7 @@
 						gapFillStr += '</select>';
 						
 					} else { // fill in the blank
-						gapFillStr += '<input type="text" id="gap' + (i-1)/2 + '" value="' + decodedAnswer + '" tabindex="' + tabIndex + '"/>';
+						gapFillStr += '<input type="text" id="gap' + (i-1)/2 + '" value="' + decodedAnswer + '" tabindex="' + tabIndex + '" autocapitalize="none"/>';
 
 						var tempArray = [];
 						tempArray = decodedAnswer.split(delimiter);


### PR DESCRIPTION
Adding `autocapitalize="none"` to the `<input>` element of the *Fill in Blank* answer, will disable auto capitalization on iOS. Although Xerte is not case sensitive by default (will treat capitalized answer as correct as well), this gives a much better end user experience.

See [Apple Safari HTML Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize)