### PR TITLE
No auto-complete and correct for Fill in Blank

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -186,7 +186,7 @@
 						gapFillStr += '</select>';
 						
 					} else { // fill in the blank
-						gapFillStr += '<input type="text" id="gap' + (i-1)/2 + '" value="' + decodedAnswer + '" tabindex="' + tabIndex + '"/>';
+						gapFillStr += '<input type="text" id="gap' + (i-1)/2 + '" value="' + decodedAnswer + '" tabindex="' + tabIndex + 'autocomplete="off" autocorrect="off" spellcheck="false"' + '"/>';
 
 						var tempArray = [];
 						tempArray = decodedAnswer.split(delimiter);


### PR DESCRIPTION
Add `autocomplete="off" autocorrect="off" spellcheck="false"` attributes to the `<input>` element of the *Fill in Blank* answer. This will disable auto-completion and auto-correction for (iOS) Safari and other browsers.

See [Apple Safari HTML Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize)

See [Mozilla spellcheck attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck)