### PR TITLE
Bugfix: tabIndexx++ for submitBtn in setUpDragDrop

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -546,6 +546,7 @@
 
 				
 			} else {
+				tabIndex++;
 				$("#submitBtn")
 					.button({
 						label:	x_currentPageXML.getAttribute("checkBtn") != undefined && x_currentPageXML.getAttribute("checkBtn") != "" ? x_currentPageXML.getAttribute("checkBtn") : "Check"


### PR DESCRIPTION
This is a **bugfix** to prevent the `#submitBtn` in `setUpDragDrop` to get the same tab-index as the previous item. This is the same as the `tabIndex++;` on line 491 for `setUpFillBlank` for example.