### PR TITLE
Removed tab-index from non-target Gap Fill texts

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -26,7 +26,7 @@
 			labelTxt3,
 			targetTxt1,
 			targetTxt2,
-			tabIndex = 1,
+			tabIndex = 0,
 			answerData,
             allDropDownAnswers,
 			delimiter,
@@ -149,11 +149,11 @@
 
             allDropDownAnswers = [];
             for (var i=0; i<passageArray.length; i++) {
-				tabIndex++;
 				if (markedWord == false) {
-					gapFillStr += '<span tabindex="' + tabIndex + '">' + passageArray[i] + '</span>';
+					gapFillStr += '<span>' + passageArray[i] + '</span>';
 					markedWord = true;
 				} else {
+					tabIndex++;
 					decodedAnswer = $("<textarea/>").html(passageArray[i]).text();
 					if (x_currentPageXML.getAttribute("interactivity") == "Drag Drop") {
 						gapFillStr += '<span id="gap' + (i-1)/2 + '" class="target highlight" tabindex="' + tabIndex + '">' + decodedAnswer + '</span>';
@@ -363,7 +363,6 @@
 				$feedbackTxt.hide();
 			});
 			
-			$feedbackTxt.attr("tabindex", tabIndex+1);
 		}
 		
 		this.setUpFillBlank = function() {
@@ -535,7 +534,6 @@
 				});
 			}
 			
-			$feedbackTxt.attr("tabindex", tabIndex+1);
 		}
 		
 		this.setUpDragDrop = function() {
@@ -706,7 +704,6 @@
 				});
 			}
 			
-			$feedbackTxt.attr("tabindex", tabIndex+1);
 		}
 		
 		// function called when label dropped on target - by mouse or keyboard
@@ -1230,7 +1227,7 @@
 	<div class="splitScreen">
 		
 		<div id="textHolder" class="left">
-			<div id="mainText" tabindex="1"></div>
+			<div id="mainText"></div>
 		</div>
 		
 		<div id="dragDropHolder" class="right">


### PR DESCRIPTION
One could argue that also the *non-target texts* should have a tab-index, but I think its better to go from one *answer target* straight to the next *answer target* or the *next button*. In other words; I don't see why Introtext, Text surrounding targets and Feedback should have a tab-index. This changes:

- Defines `tabIndex = 0` instead of `tabIndex = 1` because I remove the  *Introductory Text* tab-index.
- Removes the tab-indexes from the *text* surrounding the *target*.
- Removes all *FeedbackTxt* tab-indexes.
- Removes the `tabindex="1"` from `mainText` to remove the  *Introductory Text* tab-index.