### PR TITLE
Only hide feedback if Fill in Blank is readonly

### DIFF
--- a/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
+++ b/modules/xerte/parent_templates/Nottingham/models_html5/gapFill.html
@@ -520,6 +520,7 @@
 								$this.attr("readonly", "readonly");
 								$this.attr("correct", "correct");
 							} else {
+								$this.attr("readonly", "readonly");
 								$this.val(answerData[$this.data("index")][0]);
 								$this.addClass("answerShown");
 							}
@@ -531,7 +532,9 @@
 					});
 				
 				$targetHolder.find("input").on("keypress", function() {
-					$feedbackTxt.hide();
+					if($(this).attr("readonly")!=="readonly"){
+						$feedbackTxt.hide();
+					}
 				});
 			}
 			


### PR DESCRIPTION
Only hide the feedbackTxt if *Fill in Blank* `<input>` element has attribute `readonly`.
This prevents the feedbackTxt from disappearing when one shift-tabs focus on the *correct* or *shown answer* in the `<input>` element and does a keypress.

I also added the `readonly` attribute  to the `<input>` element if the show answer button is pressed.