### PR TITLE
Change wrong argumenttype pageCompleted(page_nr)

### DIFF
--- a/modules/xerte/scorm2004.3rd/xttracking_scorm2004.3rd.js
+++ b/modules/xerte/scorm2004.3rd/xttracking_scorm2004.3rd.js
@@ -596,7 +596,7 @@ function ScormTrackingState()
                         if (sit != null) {
                             //Skip results page completely
                             if (sit.ia_type != "result") {
-                                state.completedPages[i] = state.pageCompleted(page_nr);
+                                state.completedPages[i] = state.pageCompleted(sit);
                             }
                         }
                     }


### PR DESCRIPTION
When trying to get the completion status of a Scorm2004 3rd edition
package in Moodle and in 360Learning I noticed that the packages
never completed.

When debugging the JavaScript code I noticed an inconsistency between
the function call 'state.pageCompleted(page_nr)' and the function
definition 'function pageCompleted(sit)'.

The problem seems to have arisen on July 21 2017. When aligning
the names of the variables, the argument of state.pageCompleted()
was changed from 'sit' to 'page_nr'. I think this might be the reason
that my Scorm modules in Moodle and 360Learning had a 'not completed'
status.