### PR TITLE
Lockfile corrections

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -85,25 +85,25 @@ if(isset($_SESSION['toolkits_logon_id'])){
 
 			// Check for multiple editors
 			if(has_template_multiple_editors($safe_template_id)){
-				// Check for lock file. A lock file is created to prevent more than one
+				// Check for lock file. A lock file is created to prevent more than one editor editing the same template at the same time
 				if(file_exists($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt")){
 
 					// Lock file exists, so open it up and see who created it
 					$lock_file_data = file_get_contents($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt");
 
-					$temp = explode("*",$lock_file_data);
-
-					if(count($temp)==1){
-						$temp = explode(" ",$lock_file_data);
-					}
+					$temp = explode("*", $lock_file_data);
 
 					$lock_file_creator = $temp[0];
-                                    
+
+					// get username only
+					$temp = explode(" ", $lock_file_creator);
+					$lock_file_creator_username = $temp[0];
+
 					/*
 					 * Check if lock file creator is current user, if so, continue into the code
 					 */
 
-					if($lock_file_creator==$_SESSION['toolkits_logon_username']) {
+					if($lock_file_creator_username==$_SESSION['toolkits_logon_username']) {
 						if(update_access_time($row_edit)) {
 							// Display the editor
 							require $xerte_toolkits_site->root_file_path . "modules/" . $row_edit['template_framework'] . "/edit.php";
@@ -119,12 +119,12 @@ if(isset($_SESSION['toolkits_logon_id'])){
 						if(isset($_POST['lockfile_clear'])) {
 
 							/*
-							 * Delete the lockfile
+							 * Modify the lockfile to just the user entry
 							 */
 
 							$file_handle = fopen($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt", 'w');
 
-							fwrite($file_handle, $_SESSION['toolkits_logon_username'] . "*");
+							fwrite($file_handle, $_SESSION['toolkits_logon_username'] . " (" . date("Y-m-d H:i:s") . ")*");
 
 							fclose($file_handle);
 
@@ -144,12 +144,14 @@ if(isset($_SESSION['toolkits_logon_id'])){
 						}
 						else {
 
-							// Update the lock file. The lock file format is creator id*id that tried to access 1 <space> id that tried to access 2 and so on
-							$new_lock_file = $lock_file_data . $_SESSION['toolkits_logon_username'] . " ";
+							// Update the lock file. The lock file format is: creator_id (date/time)*[user_id (date/time),...]
+							// where 'user_id' are users who tried to edit the template when it was already being edited
+
+							$new_lock_file = $lock_file_data . $_SESSION['toolkits_logon_username'] . " (" . date("Y-m-d H:i:s") . "),";
 							$file_handle = fopen($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt",'w');
 							fwrite($file_handle, $new_lock_file);
 							fclose($file_handle);
-							output_locked_file_code($lock_file_creator);
+							output_locked_file_code($lock_file_creator_username);
 						}
 					}
 				}
@@ -157,7 +159,7 @@ if(isset($_SESSION['toolkits_logon_id'])){
 
 					// No lock file, so create one
 					$file_handle = fopen($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt", 'w');
-					fwrite($file_handle, $_SESSION['toolkits_logon_username'] . "*");
+					fwrite($file_handle, $_SESSION['toolkits_logon_username'] . " (" . date("Y-m-d H:i:s") . ")*");
 					fclose($file_handle);
 
 					// Update the time this template was last edited
@@ -185,7 +187,7 @@ if(isset($_SESSION['toolkits_logon_id'])){
 			}
 		}
 		else {
-			// One editor (and no sharing) for this prohect, so continue without creating a lock file
+			// One editor (and no sharing) for this project, so continue without creating a lock file
 			if(update_access_time($row_edit)){
 				_debug("editphp - no sharing etc");
 				require $xerte_toolkits_site->root_file_path . "modules/" . $row_edit['template_framework'] . "/edit.php";

--- a/edithtml.php
+++ b/edithtml.php
@@ -88,27 +88,23 @@ if(isset($_SESSION['toolkits_logon_id'])){
 			// Check for multiple editors
 			//if(has_template_multiple_editors($safe_template_id)){
 
-				// Check for lock file. A lock file is created to prevent more than one
+				// Check for lock file. A lock file is created to prevent more than one editor editing the same template at the same time
 				if(file_exists($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt")){
 
 					// Lock file exists, so open it up and see who created it
 					$lock_file_data = file_get_contents($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt");
 
-					$temp = explode("*",$lock_file_data);
-
-					if(count($temp)==1){
-						$temp = explode(" ",$lock_file_data);
-					}
+					$temp = explode("*", $lock_file_data);
 
 					$lock_file_creator = $temp[0];
 
 					// get username only
-                    $temp = explode(" ", $temp[0]);
-                    $lock_file_creator_username = $temp[0];
+					$temp = explode(" ", $lock_file_creator);
+					$lock_file_creator_username = $temp[0];
 
-                    /*
-                     * Check if lock file creator is current user, if so, continue into the code
-                     */
+					/*
+					 * Check if lock file creator is current user, if so, continue into the code
+					 */
 
 					//if($lock_file_creator_username==$_SESSION['toolkits_logon_username']) {
 					//	if(update_access_time($row_edit)) {
@@ -126,7 +122,7 @@ if(isset($_SESSION['toolkits_logon_id'])){
 						if(isset($_POST['lockfile_clear'])) {
 
 							/*
-							 * Delete the lockfile
+							 * Modify the lockfile to just the user entry
 							 */
 
 							$file_handle = fopen($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt", 'w');
@@ -151,12 +147,13 @@ if(isset($_SESSION['toolkits_logon_id'])){
 						}
 						else {
 
-							// Update the lock file. The lock file format is creator id*id that tried to access 1 <space> id that tried to access 2 and so on
-							$new_lock_file = $lock_file_data . $_SESSION['toolkits_logon_username'] . " (" . date("Y-m-d H:i:s") . "), ";
+							// Update the lock file. The lock file format is: creator_id (date/time)*[user_id (date/time),...]
+							// where 'user_id' are users who tried to edit the template when it was already being edited
+							$new_lock_file = $lock_file_data . $_SESSION['toolkits_logon_username'] . " (" . date("Y-m-d H:i:s") . "),";
 							$file_handle = fopen($xerte_toolkits_site->users_file_area_full . $row_edit['template_id'] . "-" . $row_edit['username'] . "-" . $row_edit['template_name'] . "/lockfile.txt",'w');
 							fwrite($file_handle, $new_lock_file);
 							fclose($file_handle);
-							output_locked_file_code($lock_file_creator);
+							output_locked_file_code($lock_file_creator_username);
 						}
 					//}
 				}
@@ -193,7 +190,7 @@ if(isset($_SESSION['toolkits_logon_id'])){
 		}
 		else {
 			// Read-only access!
-            die("Access denied, you have no editing rights to this object.");
+			die("Access denied, you have no editing rights to this object.");
 		}
 	}
 	else if(is_user_admin()) {

--- a/languages/en-GB/website_code/php/display_library.inc
+++ b/languages/en-GB/website_code/php/display_library.inc
@@ -29,11 +29,11 @@
 	
 	define("DISPLAY_EDITED", "This project is currently being edited by ");
 	
-	define("DISPLAY_LOCKFILE_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue, and there are two or more people editing at once, there is a risk that you will loose work or that the project will become corrupted. Otherwise, please wait and you will be automatically emailed when the current editor closes the project down.");
+	define("DISPLAY_LOCKFILE_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue, and there are two or more people editing at once, there is a risk that you will lose work or that the project will become corrupted. Otherwise, please wait and you will be automatically emailed when the current editor closes the project down.");
 
 	define("DISPLAY_LOCKFILE_YOU", "you");
 
-	define("DISPLAY_LOCKFILE_YOU_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue and you are editing in another browser or another PC, there is a risk that you will loose work or that the project will become corrupted. Please verify you are not editing the file in another system.");
+	define("DISPLAY_LOCKFILE_YOU_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue, and you are editing in another browser or another PC, there is a risk that you will lose work or that the project will become corrupted. Please verify you are not editing the file in another system.");
 
 	define("DISPLAY_LOCKFILE_DELETE", "Delete Lockfile");
 

--- a/languages/en-GB/website_code/php/display_library.inc
+++ b/languages/en-GB/website_code/php/display_library.inc
@@ -12,9 +12,9 @@
 	 
 
 	define("DISPLAY_RECYCLE", "Recycle Bin");
-	
+
 	define("DISPLAY_EXAMPLE", "See example");
-	
+
 	define("DISPLAY_CREATE", "Create");
 
     define("DISPLAY_BUTTON_PROJECT_CREATE", "Create Project");
@@ -29,7 +29,7 @@
 	
 	define("DISPLAY_EDITED", "This project is currently being edited by ");
 	
-	define("DISPLAY_LOCKFILE_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue and there are two people editing at once, there is a risk that you will loose work or that the project will become corrupted. Otherwise, please wait until the current editor closes the project and it will be made available to you when the current editor closes it down.");
+	define("DISPLAY_LOCKFILE_MESSAGE", "If you are sure this is not the case, then you can edit the project by clicking the button below. If you continue, and there are two or more people editing at once, there is a risk that you will loose work or that the project will become corrupted. Otherwise, please wait and you will be automatically emailed when the current editor closes the project down.");
 
 	define("DISPLAY_LOCKFILE_YOU", "you");
 

--- a/website_code/php/versioncontrol/template_close.php
+++ b/website_code/php/versioncontrol/template_close.php
@@ -85,7 +85,7 @@ if(file_exists($xerte_toolkits_site->users_file_area_full . $_POST['file_path'] 
 		$users_array[$username] = 1;
 	}
 
-        mail($username . $mail_domain, "File available - \"" . str_replace("_"," ",$row_template_name['template_name']) ."\"", "Hello, <br><br> You've requested to be informed when the file \"" . str_replace("_"," ",$row_template_name['template_name']) . "\" becomes available for editing. The file was made available at " . date("h:i a") . " on " . date("l, jS F") . " <br><br> Please note that multiple requests may have been made, and as such you may not be the only person to have received one of these notifications. As such the file may well be locked by somebody else.<br><br> Please log into the site at <a href=\"" . $xerte_toolkits_site->site_url . "\">" . $xerte_toolkits_site->site_url . "</a>. <br><br> Thank you, <br><br> the Xerte Online toolkits team", get_email_headers());
+        mail($username . $mail_domain, "File available - \"" . str_replace("_"," ",$row_template_name['template_name']) ."\"", "Hello, <br><br> This is to notify you that the Xerte file \"" . str_replace("_"," ",$row_template_name['template_name']) . "\" has become available for editing. The file was made available at " . date("h:i a") . " on " . date("l, jS F") . " <br><br> Please note that multiple attempts to edit the file may have been made, and as such you may not be the only person to have received one of these notifications. For that reason the file may soon become locked again by another user.<br><br> Please log into the site at <a href=\"" . $xerte_toolkits_site->site_url . "\">" . $xerte_toolkits_site->site_url . "</a>. <br><br> Thank you, <br><br> the Xerte Online toolkits team", get_email_headers());
 
     }
 

--- a/website_code/php/versioncontrol/template_close.php
+++ b/website_code/php/versioncontrol/template_close.php
@@ -37,7 +37,9 @@ _load_language_file("/website_code/php/versioncontrol/template_close.inc");
 
 require('../template_status.php');
 
-$temp_array = explode("-",$_POST['file_path']);
+$users_array = array();
+
+$temp_array = explode("-", $_POST['file_path']);
 
 database_connect("template close success","template close fail");
 
@@ -47,20 +49,17 @@ if(file_exists($xerte_toolkits_site->users_file_area_full . $_POST['file_path'] 
      *  Code to delete the lock file
      */
 
+    $row_template_name = db_query_one("Select template_name from {$xerte_toolkits_site->database_table_prefix}templatedetails WHERE template_id = ?", array($temp_array[0]));
+
     $lock_file_data = file_get_contents($xerte_toolkits_site->users_file_area_full . $temp_array[0] . "-" . $temp_array[1] . "-" . $temp_array[2] . "/lockfile.txt");
 
-    $temp = explode("*",$lock_file_data);
+    $temp = explode("*", $lock_file_data);
 
     $lock_file_creator = $temp[0];
 
-    $template_id = explode("-",$_POST['file_path']);
-
-    $row_template_name = db_query_one("Select template_name from {$xerte_toolkits_site->database_table_prefix}templatedetails WHERE template_id = ?", array($template_id[0]));
-
-
     $user_list = $temp[1];
 
-    $users = explode(" ",$user_list);
+    $users = explode(",", $user_list);
 
     /*
      * Email users in the lock file
@@ -74,9 +73,19 @@ if(file_exists($xerte_toolkits_site->users_file_area_full . $_POST['file_path'] 
 
     for($x=0;$x!=count($users)-1;$x++){
 
-        if ($users[$x] != $_SESSION['toolkits_logon_username']) {
-            mail($users[$x] . $mail_domain, "File available - \"" . str_replace("_", " ", $row_template_name['template_name']) . "\"", "Hello, <br><br> You've requested to be informed when the file \"" . str_replace("_", " ", $row_template_name['template_name']) . "\" becomes available for editing. The file was made available at " . date("h:i a") . " on " . date("l, jS F") . " <br><br> Please note that multiple requests may have been made, and as such you may not be the only person to have receive one of these notifications. As such the file may well be locked by somebody else.<br><br> Please log into the site at <a href=\"" . $xerte_toolkits_site->site_url . "\">" . $xerte_toolkits_site->site_url . "</a>. <br><br> Thank you, <br><br> the Xerte Online toolkits team", get_email_headers());
-        }
+	// get just the username
+	$userdata = explode(" ", $users[$x]);
+	$username = $userdata[0];
+
+	// check if a message has already been sent to this user
+	if (isset($users_array[$username])) {
+		continue;
+	}
+	else {
+		$users_array[$username] = 1;
+	}
+
+        mail($username . $mail_domain, "File available - \"" . str_replace("_"," ",$row_template_name['template_name']) ."\"", "Hello, <br><br> You've requested to be informed when the file \"" . str_replace("_"," ",$row_template_name['template_name']) . "\" becomes available for editing. The file was made available at " . date("h:i a") . " on " . date("l, jS F") . " <br><br> Please note that multiple requests may have been made, and as such you may not be the only person to have received one of these notifications. As such the file may well be locked by somebody else.<br><br> Please log into the site at <a href=\"" . $xerte_toolkits_site->site_url . "\">" . $xerte_toolkits_site->site_url . "</a>. <br><br> Thank you, <br><br> the Xerte Online toolkits team", get_email_headers());
 
     }
 


### PR DESCRIPTION
This pull request relates to issues #909 and #842 

The date/time is now added to the lockfile for each user, and the username is correctly extracted when sending out the email notifications.
As mention in #842 only one notification is sent out per user. Also from that issue, the email message wording has been changed. The user did not 'request' notification, they have no way to do that. So it now simply says that the user is being notified.
