### PR TITLE
Corrected Missing Comma

### DIFF
--- a/setup/basic.sql
+++ b/setup/basic.sql
@@ -231,7 +231,7 @@ CREATE TABLE `$templaterights` (
   `user_id` bigint(20) DEFAULT NULL,
   `role` char(255) DEFAULT NULL,
   `folder` bigint(20) DEFAULT NULL,
-  `notes` char(255) DEFAULT NULL
+  `notes` char(255) DEFAULT NULL,
    KEY `index1` (`template_id`,`user_id`,`role`(10))
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 


### PR DESCRIPTION
Getting error while install of xerte 3.10.4

#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '\`index1\` (\`template_id\`,\`user_id\`,\`role\`(10))
) ENGINE=MyISAM DEFAULT CHARSET=u' at line 7 

PR -- ```Corrected Missing Comma of templaterights Table```