### PR TITLE
Ghost xertelogin.php to Saml2login.php

### DIFF
--- a/library/Xerte/Authentication/Saml2.php.dist
+++ b/library/Xerte/Authentication/Saml2.php.dist
@@ -63,11 +63,11 @@ class Xerte_Authentication_Saml2 extends Xerte_Authentication_Abstract
     /** Saml2 integration */
     public function needsLogin()
     {
-        // Redirect to sso site with xertelogin.php RelayState
-        // sso site should do a saml sso, and the RelayState xertelogin.php, should POST all required data to
-        // <this website>/library/Xerte/Authentication/Saml2/xertelogin.php
+        // Redirect to sso site with saml2login.php RelayState
+        // sso site should do a saml sso, and the RelayState saml2login.php, should POST all required data to
+        // <this website>/library/Xerte/Authentication/Saml2/saml2login.php
         //
-        // The latter xertelogin.php should set the SESSION as required and the _record
+        // The latter saml2login.php should set the SESSION as required and the _record
         //
         // This implementation is based on One_Logins Saml2 php implementation
 


### PR DESCRIPTION
Hi, sorry if this is not how you are meant to do this but I just made an account to fix this. The instruction comment refers to a non-existent "xertelogin.php" that is actually called "saml2login.php" so I have updated it